### PR TITLE
Use Jekyll::Utils.slugify method defined in Jekyll 2.4

### DIFF
--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-archives.rb", "lib/jekyll-archives/archive.rb"]
 
-  s.add_dependency "jekyll", '~> 2.0'
+  s.add_dependency "jekyll", '~> 2.4'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -27,11 +27,9 @@ module Jekyll
       @type  = type
       @name  = name
 
-      # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
+      # Generate slug if tag or category
       if name.is_a? String
-        @slug = name.split(" ").map { |w|
-          w.downcase.gsub(/[^\w]/, '')
-        }.join("-")
+        @slug = Utils.slugify(name)
       end
 
       # Use ".html" for file extension and url for path


### PR DESCRIPTION
`Jekyll::Utils.slugify` is defined in Jekyll 2.4. Use this method instead of implementing it in `lib/jekyll-archives/archive.rb`.
