### PR TITLE
Change jekyll dependency to be ~> 2.4

### DIFF
--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-archives.rb", "lib/jekyll-archives/archive.rb"]
 
-  s.add_dependency "jekyll", '~> 2.0'
+  s.add_dependency "jekyll", '~> 2.4'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'


### PR DESCRIPTION
- 8bbfaf60831369698b141da72fb8d71a0a7b0c43 used `Utils.slugify` which has been added in 2.4
