### PR TITLE
Update documentation to reflect changes in v2.0.0

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -31,7 +31,7 @@ This attribute contains a simple string indicating the type of the layout being 
 
 #### Year layout
 ```html
-<h1>Archive of posts from {{ page.title | date: "%Y" }}</h1>
+<h1>Archive of posts from {{ page.date | date: "%Y" }}</h1>
 
 <ul class="posts">
 {% for post in page.posts %}
@@ -45,7 +45,7 @@ This attribute contains a simple string indicating the type of the layout being 
 
 #### Month layout
 ```html
-<h1>Archive of posts from {{ page.title | date: "%B %Y" }}</h1>
+<h1>Archive of posts from {{ page.date | date: "%B %Y" }}</h1>
 
 <ul class="posts">
 {% for post in page.posts %}
@@ -59,7 +59,7 @@ This attribute contains a simple string indicating the type of the layout being 
 
 #### Day layout
 ```html
-<h1>Archive of posts from {{ page.title | date: "%B %-d, %Y" }}</h1>
+<h1>Archive of posts from {{ page.date | date: "%B %-d, %Y" }}</h1>
 
 <ul class="posts">
 {% for post in page.posts %}


### PR DESCRIPTION
If I understand the changes correctly, we should use `page.date` on date-based archives pages, as `page.title` will return `nil`.