### PR TITLE
Slug Creation Should Allow Numbers

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -30,6 +30,8 @@ module Jekyll
       end
 
       def generate(site)
+        puts "       - Generating Archives..."
+        
         @site = site
         @posts = site.posts
         @archives = []

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -30,8 +30,6 @@ module Jekyll
       end
 
       def generate(site)
-        puts "       - Generating Archives..."
-        
         @site = site
         @posts = site.posts
         @archives = []

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -34,8 +34,8 @@ module Jekyll
         @config = site.config['jekyll-archives']
 
         # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
-        if title.is_a? String
-          @slug = Utils.slugify(title)
+        if title.to_s.length
+          @slug = Utils.slugify(title.to_s)
         end
 
         # Use ".html" for file extension and url for path


### PR DESCRIPTION
I have a site which uses years as tags. Because this value previously checked for String objects only, the slug would not be set, and the value would be nil for later where a crash would occur.

Forcing a to_s and checking length will allow numbers, or pretty much any object that is listed under tags to get through.