### PR TITLE
Disable incremental regen when Archives enabled for 3.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 test/destination
 .bundle
 pkg/
+.jekyll-metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,20 @@
+language: ruby
+script : script/cibuild
+sudo: false
+
 rvm:
-- 2.1
-- 2.0
-- 1.9.3
+  - 2.2
+  - 2.1
+  - 2.0
+env:
+  - ""
+  - JEKYLL_VERSION=3.0.0.beta8
+  - JEKYLL_VERSION=2.0
+matrix:
+  include:
+    - # GitHub Pages
+      rvm: 2.1.1
+      env: GH_PAGES=true
+    - # Ruby 1.9
+      rvm: 1.9
+      env: JEKYLL_VERSION=2.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source 'https://rubygems.org'
 gemspec
+
+if ENV["GH_PAGES"]
+  gem "github-pages"
+elsif ENV["JEKYLL_VERSION"]
+  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-archives.rb", "lib/jekyll-archives/archive.rb"]
 
-  s.add_dependency "jekyll", '>= 2.4'
+  s.add_dependency "jekyll", '~> 3.0.0.pre.beta8'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-archives.rb", "lib/jekyll-archives/archive.rb"]
 
-  s.add_dependency "jekyll", '~> 3.0.0.pre.beta8'
+  s.add_dependency "jekyll", '>= 2.4'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -6,6 +6,12 @@ module Jekyll
     autoload :Archive, 'jekyll-archives/archive'
     autoload :VERSION, 'jekyll-archives/version'
 
+    Jekyll::Hooks.register :site, :after_reset do |site|
+      # We need to disable incremental regen for Archives to generate with the
+      # correct content
+      site.regenerator.instance_variable_set(:@disabled, true)
+    end
+
     class Archives < Jekyll::Generator
       safe true
 

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -6,10 +6,12 @@ module Jekyll
     autoload :Archive, 'jekyll-archives/archive'
     autoload :VERSION, 'jekyll-archives/version'
 
-    Jekyll::Hooks.register :site, :after_reset do |site|
-      # We need to disable incremental regen for Archives to generate with the
-      # correct content
-      site.regenerator.instance_variable_set(:@disabled, true)
+    if (Jekyll.const_defined? :Hooks)
+      Jekyll::Hooks.register :site, :after_reset do |site|
+        # We need to disable incremental regen for Archives to generate with the
+        # correct content
+        site.regenerator.instance_variable_set(:@disabled, true)
+      end
     end
 
     class Archives < Jekyll::Generator

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,3 +1,4 @@
 #! /bin/sh
+set -e
 
 bundle exec rake test


### PR DESCRIPTION
Incremental regen messes up the content of generated archives (they show raw content instead of generated content), so we need to disable it if `jekyll-archives` is included as a gem.

_Should_ fix the failing test(s) from #47.

@parkr @pathawks 
