### PR TITLE
Update Jekyll-Archives on RubyGems.org to support Jekyll 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0
 env:
   - ""
-  - JEKYLL_VERSION=3.0.0.beta8
+  - JEKYLL_VERSION=3.0.0
   - JEKYLL_VERSION=2.0
 matrix:
   include:

--- a/lib/jekyll-archives/version.rb
+++ b/lib/jekyll-archives/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Archives
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
   end
 end


### PR DESCRIPTION
@alfredxing 
@parkr 

I'm using [Bundler](http://bundler.io) in order to manage gem dependencies for Jekyll. In order to upgrade to Jekyll 3, I was running the command `bundle update`. Unfortunately Bundle wasn't upgrading to v3.0.0 and was still using Jekyll 2. After investigation i found out only removing "jekyll-archives" from the Gemfile will solve the problem. 

Reason: 
The [Gem page on RubyGems.org](https://rubygems.org/gems/jekyll-archives) is using v2.0.0 with the fixed dependency `jekyll ~> 2.4`. See attached screenshot.

![ja-rubygems](https://cloud.githubusercontent.com/assets/156138/10766778/7f03ff54-7cf2-11e5-8f12-0c4aa6c2f89e.png)


On the master branch (aka HEAD) the dependency issue is already [fixed](https://github.com/jekyll/jekyll-archives/blob/master/jekyll-archives.gemspec#L16).
So let's increase the version of Jekyll-Archives, so that the changes for Jekyll 3 will be available on RubyGems.org.


**ToDo after merge:**

- Add release tag "v2.1.0"
- Publish version 2.1.0 on RubyGems.org

