### PR TITLE
Set `site_payload["page"]` directly

### DIFF
--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -97,9 +97,9 @@ module Jekyll
       #
       # Returns nothing.
       def render(layouts, site_payload)
-        payload = Utils.deep_merge_hashes({
+        payload = Utils.deep_merge_hashes(site_payload, {
           "page" => to_liquid
-        }, site_payload)
+        })
 
         do_layout(payload, layouts)
       end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -97,9 +97,8 @@ module Jekyll
       #
       # Returns nothing.
       def render(layouts, site_payload)
-        payload = Utils.deep_merge_hashes(site_payload, {
-          "page" => to_liquid
-        })
+        payload = site_payload.dup
+        payload["page"] = to_liquid
 
         do_layout(payload, layouts)
       end


### PR DESCRIPTION
The way `Utils.deep_merge_hashes` is supposed to work is with the base hash *first* and the override hash *second*. Previously, we were calling with the parameters swapped, and it worked ok because `site_payload` did not have a **page** key to override. In Jekyll 3.1, `site_payload` has a **page** key that is nil, so the nil overrides all of the data we were trying to merge.

Since this worked with Jekyll 3.0 and not on Jekyll 3.1, is this a breaking change in Jekyll? Or were we just trying to use `Utils.deep_merge_hashes` in an unsupported way that has now been patched?

jekyll/jekyll#4326