### PR TITLE
Render layouts with full `site.archives`

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -45,14 +45,15 @@ module Jekyll
         @site.config['jekyll-archives'] = @config
 
         read
-        render
-        write
 
         @site.keep_files ||= []
         @archives.each do |archive|
           @site.keep_files << archive.relative_path
         end
         @site.config["archives"] = @archives
+
+        render
+        write
       end
 
       # Read archive data from posts

--- a/test/source/_layouts/archive-site-archives.html
+++ b/test/source/_layouts/archive-site-archives.html
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{{ site.archives.size }}

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -65,6 +65,24 @@ class TestJekyllArchives < Minitest::Test
     end
   end
 
+  context "the jekyll-archives plugin with layout using {{ site.archives }}" do
+    setup do
+      @site = fixture_site({
+        "jekyll-archives" => {
+          "enabled" => true,
+          "layout" => "archive-site-archives"
+        }
+      })
+      @site.process
+    end
+
+    should "populate the {{ site.archives }} tag in archives layout" do
+      assert_equal 12, read_file("/2014/index.html").to_i
+      assert_equal 12, read_file("/2013/index.html").to_i
+      assert_equal 12, read_file("/tag/test-tag/index.html").to_i
+    end
+  end
+
   context "the jekyll-archives plugin with type-specific layout" do
     setup do
       @site = fixture_site({


### PR DESCRIPTION
Fix #37 actually. Using `site.archives` on anywhere except the layout of jekyll-archives works, but when we render the layout of archives `site.archives` is empty. So we need to collect all archives first, and then set `site.archives` to allow accessing from the layout of jekyll-archives.