### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  jekyll: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,10 @@
 inherit_gem:
   jekyll: .rubocop.yml
+
+
+Metrics/BlockLength:
+  Exclude:
+    - test/**/*.rb
+Metrics/LineLength:
+  Exclude:
+    - test/**/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ script : script/cibuild
 sudo: false
 
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0
+  - 2.3.1
+  - 2.2.5
+  - 2.1.9
 env:
   - ""
-  - JEKYLL_VERSION=3.0.0
+  - JEKYLL_VERSION=3.0
   - JEKYLL_VERSION=2.0
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ if ENV["GH_PAGES"]
 elsif ENV["JEKYLL_VERSION"]
   gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
 end
+
+# Support for Ruby < 2.2.2 & activesupport
+gem "activesupport", "~> 4.2" if RUBY_VERSION < '2.2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
 if ENV["GH_PAGES"]
@@ -8,4 +8,4 @@ elsif ENV["JEKYLL_VERSION"]
 end
 
 # Support for Ruby < 2.2.2 & activesupport
-gem "activesupport", "~> 4.2" if RUBY_VERSION < '2.2.2'
+gem "activesupport", "~> 4.2" if RUBY_VERSION < "2.2.2"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # From jekyll/jekyll-mentions
 
-require 'rubygems'
-require 'bundler'
+require "rubygems"
+require "bundler"
 
 begin
   Bundler.setup(:default, :development, :test)
@@ -11,25 +11,22 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
-
 # Test task
 
-require 'rake'
-require 'rake/testtask'
+require "rake"
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
+  test.libs << "lib" << "test"
+  test.pattern = "test/**/test_*.rb"
 end
 
-task :default => 'test'
-
+task :default => "test"
 
 # Release task
 
 def name
-  @name ||= File.basename(Dir['*.gemspec'].first, ".*")
+  @name ||= File.basename(Dir["*.gemspec"].first, ".*")
 end
 
 def version
@@ -46,7 +43,7 @@ end
 
 desc "Release #{name} v#{version}"
 task :release => :build do
-  unless `git branch` =~ /^\* master$/
+  unless `git branch` =~ %r!^\* master$!
     puts "You must be on the master branch to release!"
     exit!
   end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jekyll", ">= 2.4"
 
+  s.add_development_dependency  "minitest"
   s.add_development_dependency  "rake"
   s.add_development_dependency  "rdoc"
-  s.add_development_dependency  "shoulda"
-  s.add_development_dependency  "minitest"
   s.add_development_dependency  "rubocop"
+  s.add_development_dependency  "shoulda"
 end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-archives/version'
+require "jekyll-archives/version"
 
 Gem::Specification.new do |s|
   s.name        = "jekyll-archives"
@@ -13,10 +13,11 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-archives.rb", "lib/jekyll-archives/archive.rb"]
 
-  s.add_dependency "jekyll", '>= 2.4'
+  s.add_dependency "jekyll", ">= 2.4"
 
-  s.add_development_dependency  'rake'
-  s.add_development_dependency  'rdoc'
-  s.add_development_dependency  'shoulda'
-  s.add_development_dependency  'minitest'
+  s.add_development_dependency  "rake"
+  s.add_development_dependency  "rdoc"
+  s.add_development_dependency  "shoulda"
+  s.add_development_dependency  "minitest"
+  s.add_development_dependency  "rubocop"
 end

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -1,12 +1,12 @@
-require 'jekyll'
+require "jekyll"
 
 module Jekyll
   module Archives
     # Internal requires
-    autoload :Archive, 'jekyll-archives/archive'
-    autoload :VERSION, 'jekyll-archives/version'
+    autoload :Archive, "jekyll-archives/archive"
+    autoload :VERSION, "jekyll-archives/version"
 
-    if (Jekyll.const_defined? :Hooks)
+    if Jekyll.const_defined? :Hooks
       Jekyll::Hooks.register :site, :after_reset do |site|
         # We need to disable incremental regen for Archives to generate with the
         # correct content
@@ -18,23 +18,23 @@ module Jekyll
       safe true
 
       DEFAULTS = {
-        'layout' => 'archive',
-        'enabled' => [],
-        'permalinks' => {
-          'year' => '/:year/',
-          'month' => '/:year/:month/',
-          'day' => '/:year/:month/:day/',
-          'tag' => '/tag/:name/',
-          'category' => '/category/:name/'
+        "layout"     => "archive",
+        "enabled"    => [],
+        "permalinks" => {
+          "year"     => "/:year/",
+          "month"    => "/:year/:month/",
+          "day"      => "/:year/:month/:day/",
+          "tag"      => "/tag/:name/",
+          "category" => "/category/:name/"
         }
-      }
+      }.freeze
 
       def initialize(config = nil)
-        if config['jekyll-archives'].nil?
-          @config = DEFAULTS
-        else
-          @config = Utils.deep_merge_hashes(DEFAULTS, config['jekyll-archives'])
-        end
+        @config = if config["jekyll-archives"].nil?
+                    DEFAULTS
+                  else
+                    Utils.deep_merge_hashes(DEFAULTS, config["jekyll-archives"])
+                  end
       end
 
       def generate(site)
@@ -42,7 +42,7 @@ module Jekyll
         @posts = site.posts
         @archives = []
 
-        @site.config['jekyll-archives'] = @config
+        @site.config["jekyll-archives"] = @config
 
         read
         render
@@ -93,7 +93,7 @@ module Jekyll
       # Checks if archive type is enabled in config
       def enabled?(archive)
         @config["enabled"] == true || @config["enabled"] == "all" || if @config["enabled"].is_a? Array
-          @config["enabled"].include? archive
+                                                                       @config["enabled"].include? archive
         end
       end
 
@@ -113,11 +113,11 @@ module Jekyll
       end
 
       def tags
-        @site.post_attr_hash('tags')
+        @site.post_attr_hash("tags")
       end
 
       def categories
-        @site.post_attr_hash('categories')
+        @site.post_attr_hash("categories")
       end
 
       # Custom `post_attr_hash` method for years
@@ -125,7 +125,7 @@ module Jekyll
         hash = Hash.new { |h, key| h[key] = [] }
 
         # In Jekyll 3, Collection#each should be called on the #docs array directly.
-        if Jekyll::VERSION >= '3.0.0' 
+        if Jekyll::VERSION >= "3.0.0"
           @posts.docs.each { |p| hash[p.date.strftime("%Y")] << p }
         else
           @posts.each { |p| hash[p.date.strftime("%Y")] << p }

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -9,7 +9,7 @@ module Jekyll
       attr_accessor :site
 
       # Attributes for Liquid templates
-      ATTRIBUTES_FOR_LIQUID = %w[
+      ATTRIBUTES_FOR_LIQUID = %w(
         posts
         type
         title
@@ -17,7 +17,7 @@ module Jekyll
         name
         path
         url
-      ]
+      ).freeze
 
       # Initialize a new Archive page
       #
@@ -31,7 +31,7 @@ module Jekyll
         @posts  = posts
         @type   = type
         @title  = title
-        @config = site.config['jekyll-archives']
+        @config = site.config["jekyll-archives"]
 
         # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
         if title.to_s.length
@@ -53,17 +53,17 @@ module Jekyll
       #
       # Returns the template String.
       def template
-        @config['permalinks'][type]
+        @config["permalinks"][type]
       end
 
       # The layout to use for rendering
       #
       # Returns the layout as a String
       def layout
-        if @config['layouts'] && @config['layouts'][type]
-          @config['layouts'][type]
+        if @config["layouts"] && @config["layouts"][type]
+          @config["layouts"][type]
         else
-          @config['layout']
+          @config["layout"]
         end
       end
 
@@ -82,12 +82,12 @@ module Jekyll
       # Returns the String url.
       def url
         @url ||= URL.new({
-          :template => template,
+          :template     => template,
           :placeholders => url_placeholders,
-          :permalink => nil
+          :permalink    => nil
         }).to_s
       rescue ArgumentError
-        raise ArgumentError.new "Template \"#{template}\" provided is invalid."
+        raise ArgumentError, "Template \"#{template}\" provided is invalid."
       end
 
       # Add any necessary layouts to this post
@@ -108,9 +108,9 @@ module Jekyll
       #
       # Returns the Hash representation of this Convertible.
       def to_liquid(attrs = nil)
-        further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map { |attribute|
+        further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map do |attribute|
           [attribute, send(attribute)]
-        }]
+        end]
 
         Utils.deep_merge_hashes(data, further_data)
       end
@@ -130,7 +130,7 @@ module Jekyll
       # Returns a Date.
       def date
         if @title.is_a? Hash
-          args = @title.values.map { |s| s.to_i }
+          args = @title.values.map(&:to_i)
           Date.new(*args)
         end
       end
@@ -150,14 +150,14 @@ module Jekyll
       #
       # Returns the destination relative path String.
       def relative_path
-        path = URL.unescape_path(url).gsub(/^\//, '')
+        path = URL.unescape_path(url).gsub(/^\//, "")
         path = File.join(path, "index.html") if url =~ /\/$/
         path
       end
 
       # Returns the object as a debug String.
       def inspect
-        "#<Jekyll:Archive @type=#{@type.to_s} @title=#{@title} @data=#{@data.inspect}>"
+        "#<Jekyll:Archive @type=#{@type} @title=#{@title} @data=#{@data.inspect}>"
       end
 
       # Returns the Boolean of whether this Page is HTML or not.

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -1,7 +1,6 @@
 module Jekyll
   module Archives
     class Archive < Jekyll::Page
-
       attr_accessor :posts, :type, :slug
 
       # Attributes for Liquid templates
@@ -30,10 +29,9 @@ module Jekyll
         @title  = title
         @config = site.config["jekyll-archives"]
 
-        # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
-        if title.is_a? String
-          @slug = Utils.slugify(title)
-        end
+        # Generate slug if tag or category
+        # (taken from jekyll/jekyll/features/support/env.rb)
+        @slug = Utils.slugify(title) if title.is_a? String
 
         # Use ".html" for file extension and url for path
         @ext  = File.extname(relative_path)
@@ -68,7 +66,7 @@ module Jekyll
       # desired placeholder replacements. For details see "url.rb".
       def url_placeholders
         if @title.is_a? Hash
-          @title.merge({ :type => @type })
+          @title.merge(:type => @type)
         else
           { :name => @slug, :type => @type }
         end
@@ -88,7 +86,7 @@ module Jekyll
       end
 
       def permalink
-        data && data.is_a?(Hash) && data['permalink']
+        data && data.is_a?(Hash) && data["permalink"]
       end
 
       # Add any necessary layouts to this post
@@ -115,7 +113,7 @@ module Jekyll
           end
         end
       end
-      
+
       # Convert this Convertible's data to a Hash suitable for use by Liquid.
       #
       # Returns the Hash representation of this Convertible.
@@ -132,9 +130,7 @@ module Jekyll
       # Returns a String (for tag and category archives) and nil for
       # date-based archives.
       def title
-        if @title.is_a? String
-          @title
-        end
+        @title if @title.is_a? String
       end
 
       # Produce a date object if a date-based archive
@@ -151,8 +147,8 @@ module Jekyll
       #
       # Returns the destination relative path String.
       def relative_path
-        path = URL.unescape_path(url).gsub(/^\//, "")
-        path = File.join(path, "index.html") if url =~ /\/$/
+        path = URL.unescape_path(url).gsub(%r!^\/!, "")
+        path = File.join(path, "index.html") if url =~ %r!\/$!
         path
       end
 

--- a/lib/jekyll-archives/version.rb
+++ b/lib/jekyll-archives/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Archives
-    VERSION = '2.1.0'
+    VERSION = "2.1.0".freeze
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,13 +1,14 @@
-# Taken from jekyll/jekyll-mentions (Copyright (c) 2014 GitHub, Inc. Licensened under the MIT).
+# Taken from jekyll/jekyll-mentions
+# (Copyright (c) 2014 GitHub, Inc. Licensened under the MIT).
 
-require 'rubygems'
-require 'minitest/autorun'
-require 'shoulda'
+require "rubygems"
+require "minitest/autorun"
+require "shoulda"
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'jekyll-archives'
+require "jekyll-archives"
 
 TEST_DIR     = File.expand_path("../", __FILE__)
 SOURCE_DIR   = File.expand_path("source", TEST_DIR)
@@ -20,7 +21,7 @@ class Minitest::Test
         Jekyll::Utils.deep_merge_hashes(
           Jekyll::Configuration::DEFAULTS,
           {
-            "source" => SOURCE_DIR,
+            "source"      => SOURCE_DIR,
             "destination" => DEST_DIR
           }
         ),

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin" do
@@ -52,7 +52,7 @@ class TestJekyllArchives < Minitest::Test
     setup do
       @site = fixture_site({
         "jekyll-archives" => {
-          "layout" => "archive-too",
+          "layout"  => "archive-too",
           "enabled" => true
         }
       })
@@ -89,10 +89,10 @@ class TestJekyllArchives < Minitest::Test
     setup do
       @site = fixture_site({
         "jekyll-archives" => {
-          "enabled" => true,
+          "enabled"    => true,
           "permalinks" => {
-            "year" => "/year/:year/",
-            "tag" => "/tag-:name.html",
+            "year"     => "/year/:year/",
+            "tag"      => "/tag-:name.html",
             "category" => "/category-:name.html"
           }
         }
@@ -168,11 +168,11 @@ class TestJekyllArchives < Minitest::Test
       })
       @site.process
       @archives = @site.config["archives"]
-      @tag_archive = @archives.detect {|a| a.type == "tag"}
-      @category_archive = @archives.detect {|a| a.type == "category"}
-      @year_archive = @archives.detect {|a| a.type == "year"}
-      @month_archive = @archives.detect {|a| a.type == "month"}
-      @day_archive = @archives.detect {|a| a.type == "day"}
+      @tag_archive = @archives.detect { |a| a.type == "tag" }
+      @category_archive = @archives.detect { |a| a.type == "category" }
+      @year_archive = @archives.detect { |a| a.type == "year" }
+      @month_archive = @archives.detect { |a| a.type == "month" }
+      @day_archive = @archives.detect { |a| a.type == "day" }
     end
 
     should "populate the title field in case of category or tag" do

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -3,10 +3,8 @@ require "helper"
 class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin" do
     setup do
-      @site = fixture_site({
-        "jekyll-archives" => {
-          "enabled" => true
-        }
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => true
       })
       @site.read
       @archives = Jekyll::Archives::Archives.new(@site.config)
@@ -50,11 +48,9 @@ class TestJekyllArchives < Minitest::Test
 
   context "the jekyll-archives plugin with custom layout path" do
     setup do
-      @site = fixture_site({
-        "jekyll-archives" => {
-          "layout"  => "archive-too",
-          "enabled" => true
-        }
+      @site = fixture_site("jekyll-archives" => {
+        "layout"  => "archive-too",
+        "enabled" => true
       })
       @site.process
     end
@@ -111,10 +107,8 @@ class TestJekyllArchives < Minitest::Test
 
   context "the archives" do
     setup do
-      @site = fixture_site({
-        "jekyll-archives" => {
-          "enabled" => true
-        }
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => true
       })
       @site.process
     end
@@ -137,10 +131,8 @@ class TestJekyllArchives < Minitest::Test
 
   context "the jekyll-archives plugin with enabled array" do
     setup do
-      @site = fixture_site({
-        "jekyll-archives" => {
-          "enabled" => ["tags"]
-        }
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["tags"]
       })
       @site.process
     end
@@ -161,10 +153,8 @@ class TestJekyllArchives < Minitest::Test
 
   context "the jekyll-archives plugin" do
     setup do
-      @site = fixture_site({
-        "jekyll-archives" => {
-          "enabled" => true
-        }
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => true
       })
       @site.process
       @archives = @site.config["archives"]


### PR DESCRIPTION
This PR is the result of adding `inherit_gem: jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.
