### PR TITLE
Make Archive subclass of Page

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -45,13 +45,8 @@ module Jekyll
         @site.config['jekyll-archives'] = @config
 
         read
-        render
-        write
+        @site.pages.concat(@archives)
 
-        @site.keep_files ||= []
-        @archives.each do |archive|
-          @site.keep_files << archive.relative_path
-        end
         @site.config["archives"] = @archives
       end
 
@@ -94,21 +89,6 @@ module Jekyll
       def enabled?(archive)
         @config["enabled"] == true || @config["enabled"] == "all" || if @config["enabled"].is_a? Array
           @config["enabled"].include? archive
-        end
-      end
-
-      # Renders the archives into the layouts
-      def render
-        payload = @site.site_payload
-        @archives.each do |archive|
-          archive.render(@site.layouts, payload)
-        end
-      end
-
-      # Write archives to their destination
-      def write
-        @archives.each do |archive|
-          archive.write(@site.dest)
         end
       end
 

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -1,15 +1,11 @@
 module Jekyll
   module Archives
-    class Archive
-      include Convertible
+    class Archive < Jekyll::Page
 
-      attr_accessor :posts, :type, :name, :slug
-      attr_accessor :data, :content, :output
-      attr_accessor :path, :ext
-      attr_accessor :site
+      attr_accessor :posts, :type, :slug
 
       # Attributes for Liquid templates
-      ATTRIBUTES_FOR_LIQUID = %w[
+      ATTRIBUTES_FOR_LIQUID = %w(
         posts
         type
         title
@@ -17,7 +13,7 @@ module Jekyll
         name
         path
         url
-      ]
+      ).freeze
 
       # Initialize a new Archive page
       #
@@ -90,31 +86,6 @@ module Jekyll
         raise ArgumentError.new "Template \"#{template}\" provided is invalid."
       end
 
-      # Add any necessary layouts to this post
-      #
-      # layouts      - The Hash of {"name" => "layout"}.
-      # site_payload - The site payload Hash.
-      #
-      # Returns nothing.
-      def render(layouts, site_payload)
-        payload = Utils.deep_merge_hashes({
-          "page" => to_liquid
-        }, site_payload)
-
-        do_layout(payload, layouts)
-      end
-
-      # Convert this Convertible's data to a Hash suitable for use by Liquid.
-      #
-      # Returns the Hash representation of this Convertible.
-      def to_liquid(attrs = nil)
-        further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map { |attribute|
-          [attribute, send(attribute)]
-        }]
-
-        Utils.deep_merge_hashes(data, further_data)
-      end
-
       # Produce a title object suitable for Liquid based on type of archive.
       #
       # Returns a String (for tag and category archives) and nil for
@@ -135,17 +106,6 @@ module Jekyll
         end
       end
 
-      # Obtain destination path.
-      #
-      # dest - The String path to the destination dir.
-      #
-      # Returns the destination file path String.
-      def destination(dest)
-        path = Jekyll.sanitized_path(dest, URL.unescape_path(url))
-        path = File.join(path, "index.html") if url =~ /\/$/
-        path
-      end
-
       # Obtain the write path relative to the destination directory
       #
       # Returns the destination relative path String.
@@ -158,11 +118,6 @@ module Jekyll
       # Returns the object as a debug String.
       def inspect
         "#<Jekyll:Archive @type=#{@type.to_s} @title=#{@title} @data=#{@data.inspect}>"
-      end
-
-      # Returns the Boolean of whether this Page is HTML or not.
-      def html?
-        true
       end
     end
   end


### PR DESCRIPTION
Make Archive a subclass of Jekyll::Page, and render it using the regular Page pipeline. This should also fix long-standing issue #28.

As with incremental regen, this would still be affected by the post-listing content bug (which I'm still thinking about how to fix!). So if users are going to use `{{ post.content}}` on archive pages, they'll probably still have to disable incremental for now.