### PR TITLE
Update Travis config and Gemfile for Ruby < 2.2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ script : script/cibuild
 sudo: false
 
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0
+  - 2.3.1
+  - 2.2.5
+  - 2.1.9
 env:
   - ""
-  - JEKYLL_VERSION=3.0.0
+  - JEKYLL_VERSION=3.0
   - JEKYLL_VERSION=2.0
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ if ENV["GH_PAGES"]
 elsif ENV["JEKYLL_VERSION"]
   gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
 end
+
+# Support for Ruby < 2.2.2 & activesupport
+gem "activesupport", "~> 4.2" if RUBY_VERSION < '2.2.2'


### PR DESCRIPTION
Activesupport kept complaining about Ruby versions, so use an older version (taken from Jekyll Gemfile) if Ruby version is < 2.2.2

Also, update Travis config with newer Jekyll & newer Ruby's