### PR TITLE
Remove dashes from archive tags

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -98,7 +98,7 @@ module Jekyll
       def remove_dashes(tags)
         cleaned_tags = []
         tags.each do |tag|
-          cleaned_tags << tag.gsub(/-/, ' ').squeeze
+          cleaned_tags << tag.gsub(/-/, ' ')
         end
         cleaned_tags
       end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -13,7 +13,6 @@ module Jekyll
         name
         path
         url
-        permalink
       ).freeze
 
       # Initialize a new Archive page
@@ -31,8 +30,8 @@ module Jekyll
         @config = site.config['jekyll-archives']
 
         # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
-        if title.is_a? String
-          @slug = Utils.slugify(title)
+        if title.to_s.length
+          @slug = Utils.slugify(title.to_s)
         end
 
         # Use ".html" for file extension and url for path
@@ -87,10 +86,6 @@ module Jekyll
         raise ArgumentError.new "Template \"#{template}\" provided is invalid."
       end
 
-      def permalink
-        data && data.is_a?(Hash) && data['permalink']
-      end
-
       # Produce a title object suitable for Liquid based on type of archive.
       #
       # Returns a String (for tag and category archives) and nil for
@@ -108,25 +103,6 @@ module Jekyll
         if @title.is_a? Hash
           args = @title.values.map { |s| s.to_i }
           Date.new(*args)
-        end
-      end
-
-      # Add dependencies for incremental mode
-      def add_dependencies
-        if defined? site.regenerator
-          archive_path = site.in_dest_dir(relative_path)
-          site.regenerator.add(archive_path)
-          @posts.each do |post|
-            site.regenerator.add_dependency(archive_path, post.path)
-          end
-        end
-      end
-
-      def regenerate?
-        if defined? site.regenerator
-          site.regenerator.regenerate?(self)
-        else
-          true
         end
       end
 

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -13,6 +13,7 @@ module Jekyll
         name
         path
         url
+        permalink
       ).freeze
 
       # Initialize a new Archive page
@@ -30,8 +31,8 @@ module Jekyll
         @config = site.config['jekyll-archives']
 
         # Generate slug if tag or category (taken from jekyll/jekyll/features/support/env.rb)
-        if title.to_s.length
-          @slug = Utils.slugify(title.to_s)
+        if title.is_a? String
+          @slug = Utils.slugify(title)
         end
 
         # Use ".html" for file extension and url for path
@@ -86,6 +87,10 @@ module Jekyll
         raise ArgumentError.new "Template \"#{template}\" provided is invalid."
       end
 
+      def permalink
+        data && data.is_a?(Hash) && data['permalink']
+      end
+
       # Produce a title object suitable for Liquid based on type of archive.
       #
       # Returns a String (for tag and category archives) and nil for
@@ -103,6 +108,25 @@ module Jekyll
         if @title.is_a? Hash
           args = @title.values.map { |s| s.to_i }
           Date.new(*args)
+        end
+      end
+
+      # Add dependencies for incremental mode
+      def add_dependencies
+        if defined? site.regenerator
+          archive_path = site.in_dest_dir(relative_path)
+          site.regenerator.add(archive_path)
+          @posts.each do |post|
+            site.regenerator.add_dependency(archive_path, post.path)
+          end
+        end
+      end
+
+      def regenerate?
+        if defined? site.regenerator
+          site.regenerator.regenerate?(self)
+        else
+          true
         end
       end
 

--- a/test/source/_posts/2016-11-09-post-with-dashed-tags.md
+++ b/test/source/_posts/2016-11-09-post-with-dashed-tags.md
@@ -1,0 +1,8 @@
+---
+title: Post with dashes
+tags:
+  - words-with-dashes
+  - words-with-spaces
+---
+
+Tags in this post have text delimited by a dash.

--- a/test/source/_posts/2016-11-09-post-with-spaced-tags.md
+++ b/test/source/_posts/2016-11-09-post-with-spaced-tags.md
@@ -1,0 +1,8 @@
+---
+title: Post with spaces
+tags:
+  - words with spaces
+  - words with dashes
+---
+
+Tags in this post have text delimited by a space.

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -16,18 +16,21 @@ class TestJekyllArchives < Minitest::Test
       @archives.generate(@site)
       assert archive_exists? @site, "2014/index.html"
       assert archive_exists? @site, "2013/index.html"
+      assert archive_exists? @site, "2016/index.html"
     end
 
     should "generate archive pages by month" do
       @archives.generate(@site)
       assert archive_exists? @site, "2014/08/index.html"
       assert archive_exists? @site, "2014/03/index.html"
+      assert archive_exists? @site, "2016/11/index.html"
     end
 
     should "generate archive pages by day" do
       @archives.generate(@site)
       assert archive_exists? @site, "2014/08/17/index.html"
       assert archive_exists? @site, "2013/08/16/index.html"
+      assert archive_exists? @site, "2016/11/09/index.html"
     end
 
     should "generate archive pages by tag" do
@@ -35,6 +38,8 @@ class TestJekyllArchives < Minitest::Test
       assert archive_exists? @site, "tag/test-tag/index.html"
       assert archive_exists? @site, "tag/tagged/index.html"
       assert archive_exists? @site, "tag/new/index.html"
+      assert archive_exists? @site, "tag/words-with-dashes/index.html"
+      assert archive_exists? @site, "tag/words-with-spaces/index.html"
     end
 
     should "generate archive pages by category" do
@@ -120,7 +125,7 @@ class TestJekyllArchives < Minitest::Test
     end
 
     should "populate the {{ site.archives }} tag in Liquid" do
-      assert_equal 12, read_file("length.html").to_i
+      assert_equal 17, read_file("length.html").to_i
     end
   end
 
@@ -173,6 +178,10 @@ class TestJekyllArchives < Minitest::Test
       @year_archive = @archives.detect {|a| a.type == "year"}
       @month_archive = @archives.detect {|a| a.type == "month"}
       @day_archive = @archives.detect {|a| a.type == "day"}
+    end
+
+    should "populate the {{ site.tags }} with tags that do not contain dashes" do
+      !@tag_archive.title.include? '-'
     end
 
     should "populate the title field in case of category or tag" do


### PR DESCRIPTION
This PR fixes a problem that was causing some tag archives to be non-existent.

#### What this fixes
Basically, it creates a custom `post_attr_hash` method that removes dashes from a tag before assigning its value to the hash that `site.tags` returns. This way there is only one reference that is a valid url when it has dashes and there is no tag conflict.

This is related to https://github.com/jekyll/jekyll-archives/pull/24

#### Why?
On our site, some dash-delimited tag archives were were inaccessible because they closely resembled tags without dashes in them. For instance, the `user-centered design` tag was being confused with the `user centered design` tag. If there was one post with each of the above tags, visiting `/tags/user-centered-design/` would bring up the post that was first in the list of `site.posts` instead of posts associated with both tags.
