### PR TITLE
Add support for multiple configurations

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -30,10 +30,15 @@ module Jekyll
       }
 
       def initialize(config = nil)
+        @configs = []
         if config['jekyll-archives'].nil?
-          @config = DEFAULTS
+          @configs << DEFAULTS
+        elsif config['jekyll-archives'].is_a? Array
+          config['jekyll-archives'].each do |c|
+            @configs << Utils.deep_merge_hashes(DEFAULTS, c)
+          end
         else
-          @config = Utils.deep_merge_hashes(DEFAULTS, config['jekyll-archives'])
+          @configs << Utils.deep_merge_hashes(DEFAULTS, config['jekyll-archives'])
         end
       end
 
@@ -42,9 +47,12 @@ module Jekyll
         @posts = site.posts
         @archives = []
 
-        @site.config['jekyll-archives'] = @config
+        @configs.each do |c|
+          @config = c
+          @site.config['jekyll-archives'] = @config
+          read
+        end
 
-        read
         @site.pages.concat(@archives)
 
         @site.config["archives"] = @archives


### PR DESCRIPTION
Allow using an array with multiple configurations in `_config.yml.`

This allow to generate different archives with different layouts for the
same type.

For instance, this example would generate two different archives in
different places and formats, one in HTML and the other with RSS.

```
jekyll-archives:
  -
    layout: archive-html
    enabled:
      - tags
    permalinks:
      tag: "/tag/:name/"
  -
    layout: archive-rss
    enabled:
      - tags
      - categories
    permalinks:
      tag: "/feed/tag/:name/"
      category: "/feed/category/:name/"
```
