### PR TITLE
Remove Travis test for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ matrix:
     - # GitHub Pages
       rvm: 2.1.1
       env: GH_PAGES=true
-    - # Ruby 1.9
-      rvm: 1.9
-      env: JEKYLL_VERSION=2.0


### PR DESCRIPTION
Hello @jekyll/archives. In the interests of keeping development of this important (IMHO!) plugin progressing, and in the spirit of being proactive (and following on from the discussion in #58), I’ve updated the Travis tests to remove tests for Ruby 1.9 ~~/Jekyll 2.0~~.

~~Somewhat related, I removed the version forking in the code, and bumped the minimum supported Jekyll version to 3.0. Controversial? Maybe, but Jekyll 3.0 is 15 months old now. *Ducks*~~