### PR TITLE
Proof of concept: Collections support

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -31,14 +31,15 @@ module Jekyll
 
       def generate(site)
         @site = site
-        @posts = site.posts
-        @archives = []
 
+        # Archive the posts collection by default
+        @site.posts.metadata['archive'] = true
+
+        @archives = []
         @site.config['jekyll-archives'] = @config
 
         read
         @site.pages.concat(@archives)
-
         @site.config["archives"] = @archives
       end
 
@@ -100,40 +101,69 @@ module Jekyll
         end
       end
 
+      def date_attr_hash(date_format, date_posts)
+        hash = Hash.new { |h, key| h[key] = [] }
+
+        date_posts.each do |p|
+          hash[p.date.strftime(date_format)] << p
+        end
+
+        hash.values.each { |posts| posts.sort!.reverse! }
+        hash
+      end
+
+      def doc_attr_hash(doc_attr)
+        hash = Hash.new { |h, key| h[key] = [] }
+
+        @site.collections.each do |name, collection|
+          if collection.metadata['archive']
+            collection.docs.each do |d|
+              case doc_attr
+              when 'tags'
+                d.data['tags'].each { |t| hash[t] << d } if d.data['tags']
+              when 'categories'
+                d.data['categories'].each { |t| hash[t] << d } if d.data['categories']
+              when 'years'
+                hash[d.date.strftime("%Y")] << d
+              end
+            end
+          end
+        end
+
+        hash.values.each { |posts| posts.sort!.reverse! }
+        hash
+      end
+
       def tags
-        @site.post_attr_hash('tags')
+        if Jekyll::VERSION >= '3.0.0'
+          doc_attr_hash('tags')
+        else
+          @site.post_attr_hash('tags')
+        end
       end
 
       def categories
-        @site.post_attr_hash('categories')
+        if Jekyll::VERSION >= '3.0.0'
+          doc_attr_hash('categories')
+        else
+          @site.post_attr_hash('categories')
+        end
       end
 
-      # Custom `post_attr_hash` method for years
       def years
-        hash = Hash.new { |h, key| h[key] = [] }
-
-        # In Jekyll 3, Collection#each should be called on the #docs array directly.
-        if Jekyll::VERSION >= '3.0.0' 
-          @posts.docs.each { |p| hash[p.date.strftime("%Y")] << p }
+        if Jekyll::VERSION >= '3.0.0'
+          doc_attr_hash('years')
         else
-          @posts.each { |p| hash[p.date.strftime("%Y")] << p }
+          date_attr_hash("%Y", @site.posts)
         end
-        hash.values.each { |posts| posts.sort!.reverse! }
-        hash
       end
 
       def months(year_posts)
-        hash = Hash.new { |h, key| h[key] = [] }
-        year_posts.each { |p| hash[p.date.strftime("%m")] << p }
-        hash.values.each { |posts| posts.sort!.reverse! }
-        hash
+        date_attr_hash("%m", year_posts)
       end
 
       def days(month_posts)
-        hash = Hash.new { |h, key| h[key] = [] }
-        month_posts.each { |p| hash[p.date.strftime("%d")] << p }
-        hash.values.each { |posts| posts.sort!.reverse! }
-        hash
+        date_attr_hash("%d", month_posts)
       end
     end
   end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -168,6 +168,7 @@ module Jekyll
       def inspect
         "#<Jekyll:Archive @type=#{@type.to_s} @title=#{@title} @data=#{@data.inspect}>"
       end
+
     end
   end
 end


### PR DESCRIPTION
## What is this?
As it stands, this plugin only supports posts, i.e. documents in the default `posts` collection. Now that collections are mature and _very_ useful, this plugin ought to support this feature of Jekyll fully. This is my attempt at achieving this. Right now, it works, but it needs input and plenty of expert review.

## How do I propose enabling collection archives?
To ensure backwards compatibility, documents in the default `site.posts` collection will continue to appear within enabled archives, but to add additional collections, you’ll need to add an `archive: true` value to each collection’s respective config, e.g.:

```
collections:
  albums:
    output: true
    archive: true
```

Is this the right approach? I also considered enabling archives via front matter defaults (and that way you could also exclude individual pages from being archived) but this felt like a separate feature.

## Code review
Arguably, some of the code I’ve added here should be provided by Jekyll’s core. For example, Jekyll’s `post_attr_hash` utility only parses posts, but there doesn’t seem to be an equivalent function to parse documents across all collections; I’ve added a `doc_attr_hash` utility to perform this function here. Or have I missed something? It should be noted that the code within this function feels fragile even to my inexperienced eyes, so I welcome improvements, optimisations and refinement.

## Next steps
- [ ] Get consensus on approach to configuration
- [ ] Review code and optimise
- [ ] Add tests
- [ ] Update documentation

* * *

I look forward to receiving feedback from the core plugin team, reviewers and others. /cc @alfredxing, @parkr, @pathawks
