### PR TITLE
Remove deprecated defs

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -84,22 +84,6 @@ module Jekyll
         end
       end
 
-      # Renders the archives into the layouts
-      def render
-        payload = @site.site_payload
-        @archives.each do |archive|
-          archive.render(@site.layouts, payload)
-        end
-      end
-
-      # Write archives to their destination
-      def write
-        @archives.each do |archive|
-          archive.write(@site.dest) if archive.regenerate?
-          archive.add_dependencies
-        end
-      end
-
       def tags
         @site.post_attr_hash('tags')
       end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -89,17 +89,6 @@ module Jekyll
         data && data.is_a?(Hash) && data["permalink"]
       end
 
-      # Add dependencies for incremental mode
-      def add_dependencies
-        if defined? site.regenerator
-          archive_path = site.in_dest_dir(relative_path)
-          site.regenerator.add(archive_path)
-          @posts.each do |post|
-            site.regenerator.add_dependency(archive_path, post.path)
-          end
-        end
-      end
-
       # Produce a title object suitable for Liquid based on type of archive.
       #
       # Returns a String (for tag and category archives) and nil for
@@ -125,14 +114,6 @@ module Jekyll
         path = URL.unescape_path(url).gsub(%r!^\/!, "")
         path = File.join(path, "index.html") if url =~ %r!\/$!
         path
-      end
-
-      def regenerate?
-        if defined? site.regenerator
-          site.regenerator.regenerate?(self)
-        else
-          true
-        end
       end
 
       # Returns the object as a debug String.

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -91,20 +91,6 @@ module Jekyll
         data && data.is_a?(Hash) && data['permalink']
       end
 
-      # Add any necessary layouts to this post
-      #
-      # layouts      - The Hash of {"name" => "layout"}.
-      # site_payload - The site payload Hash.
-      #
-      # Returns nothing.
-      def render(layouts, site_payload)
-        payload = Utils.deep_merge_hashes({
-          "page" => to_liquid
-        }, site_payload)
-
-        do_layout(payload, layouts)
-      end
-
       # Add dependencies for incremental mode
       def add_dependencies
         if defined? site.regenerator
@@ -114,17 +100,6 @@ module Jekyll
             site.regenerator.add_dependency(archive_path, post.path)
           end
         end
-      end
-      
-      # Convert this Convertible's data to a Hash suitable for use by Liquid.
-      #
-      # Returns the Hash representation of this Convertible.
-      def to_liquid(attrs = nil)
-        further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map { |attribute|
-          [attribute, send(attribute)]
-        }]
-
-        Utils.deep_merge_hashes(data, further_data)
       end
 
       # Produce a title object suitable for Liquid based on type of archive.


### PR DESCRIPTION
Reviewing the commit history of this plugin, it seems that somewhere between #67 and #58 being merged in, deprecated code that was removed was added back in again later.

The first merge, in which `Archive` became a subclass of `Page`, removed defs that were no longer required as part of this change. The merge that appears to reintroduce them is the one adding support for incremental rebuilds.

Have I read this correctly? Can we delete some code?!