### PR TITLE
Fix Travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ script : script/cibuild
 cache: bundler
 sudo: false
 
+before_install: gem update --system
+
 rvm:
   - 2.3.3
   - 2.2.6
   - 2.1.9
+
 env:
   - ""
   - JEKYLL_VERSION=3.0
   - JEKYLL_VERSION=2.0
+
 matrix:
   include:
     - # GitHub Pages


### PR DESCRIPTION
Fixes the `"can't modify frozen String"` error on recent builds. Apparently it's a problem with RubyGems and it's fixed in the latest version, so just update that in the build before running.