### PR TITLE
Multi archives

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,9 +1,5 @@
 ## HEAD
 
-### Major Enhancements
-
-  * Support for multiple archives of the same type(#94)
-
 ### Minor Enhancements
 
   * Make Archive subclass of Page (#67)

--- a/History.markdown
+++ b/History.markdown
@@ -1,5 +1,9 @@
 ## HEAD
 
+### Major Enhancements
+
+  * Support for multiple archives of the same type(#94)
+
 ### Minor Enhancements
 
   * Make Archive subclass of Page (#67)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,26 +13,37 @@ jekyll-archives:
     day: '/:year/:month/:day/'
     tag: '/tag/:name/'
     category: '/category/:name/'
+  types:
+    year: 'year'
+    month: 'month'
+    day: 'day'
+    tag: 'tag'
+    category: 'category'
 ```
 
 ### Configuration options
 
 #### Required and recommended settings
 - [Enabled archives (`enabled`)](#enabled-archives)
-- [Type-specific layouts (`layouts`)](#type-specific-layouts)
+- [Archive-specific layouts (`layouts`)](#archive-specific-layouts)
 
 #### Optional settings
 - [Default layout (`layout`)](#default-layout)
 - [Permalinks (`permalinks`)](#permalinks)
+
+#### Custom archives
+- [Archive types (`types`)](#types)
 
 ---
 
 #### Enabled archives
 | Key | Value type | Values |
 |---|---|---|---|
-| `enabled` | String or Array | `'all'` or an array of any combination of `year`, `month`, `day`, `categories`, `tags` |
+| `enabled` | String or Array | `'all'` or an array of any combination of `years`, `months`, `days`, `categories`, `tags`, or archive names (the keys in `types`, by default `year`, `month`, `day`, `category`, `tag`) |
 ##### Description
-This option sets which types of archives will be created. Must be set to an array of enabled archive types, or the string 'all' (to enable all archives).
+This option sets which types of archives will be created. Must be set to an array of enabled archives, or the string 'all' (to enable all archives).
+
+If an array is used, it may contain individual archive names, or [archive types](#types) using the plural form: year**s**, month**s**, day**s**, categor**ies**, tag**s**. When archive types are used, all archives of that type are enabled.
 ##### Sample values
 ```yml
 enabled: all
@@ -60,12 +71,12 @@ layout: custom-archive-layout    # _layouts/custom-archive-layout.html
 
 ---
 
-#### Type-specific layouts
+#### Archive-specific layouts
 | Key | Value type | Values |
 |---|---|---|---|
-| `layouts` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its archive name. |
+| `layouts` | Map, String &rarr; String | A map of archive name (the keys in `types`, by default `year`, `month`, `day`, `category`, `tag`) to its layout. |
 ##### Description
-Maps archive types to the layout they will be rendered in. Not all types need to be specified; those without a specific layout will fall back to the default layout.
+Maps archive names to the layout they will be rendered in. Not all names need to be specified; those without a specific layout will fall back to the default layout.
 ##### Sample values
 ```yml
 layouts:
@@ -80,15 +91,21 @@ layouts:
 #### Permalinks
 | Key | Value type | Values |
 |---|---|---|---|
-| `permalinks` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its permalink format. |
+| `permalinks` | Map, String &rarr; String | A map of archive name (the keys in `types`, by default `year`, `month`, `day`, `category`, `tag`) to its permalink format. |
 ##### Description
-Maps archive types to the permalink format used for archive pages. The permalink style is the same as regular Jekyll posts and pages, but with different variables.
+Maps archive names to the permalink format used for archive pages. The permalink style is the same as regular Jekyll posts and pages, but with different variables.
 
 These variables are:
 * `:year` for year archives
 * `:year` and `:month` for month archives
 * `:year`, `:month`, and `:day` for day archives
 * `:name` for category and tag archives
+
+If the permalink for an archive which is not part of the [default configuration](#default_configuration) is missing, a fallback will automatically be provided, based on the following patterns:
+* `/{archive-name}/:name/` for archives whose type is either `tag` or `category`
+* `/{archive-name}/:year/` for archives whose type is `year`
+* `/{archive-name}/:year/:month/` for archives whose type is `month`
+* `/{archive-name}/:year/:month/:day/` for archives whose type is `day`
 
 *Note:* trailing slashes are required to create the archive as an `index.html` file of a directory.
 ##### Sample values
@@ -97,4 +114,30 @@ permalinks:
   year: '/archives/year/:year/'
   month: '/archives/month/:year-:month/'
   tag: '/archives/tag/:name/`
+```
+
+#### Types
+| Key | Value type | Values |
+|---|---|---|---|
+| `permalinks` | Map, String &rarr; String | A map of archive name to archive types: `year`, `month`, `day`, `category`, `tag`. |
+##### Description
+By default, an archive of each type is declared, with the same name as its type. Therefore, in simple case, the distinction between archive type and archive name can be ignored.
+
+However, it can sometimes be useful set up multiple archives of the same type to provide different views of that same content. For instance, one view could contain a list of post titles, serving as a table of content, while an other view would include the posts' content inline.
+
+In that case, the keys of `types` are used to declare new archive names, and the values must be one of `year`, `month`, `day`, `category`, or `tag`.
+
+Archive names are what are used as keys to [`layouts`](#archive-specific-layouts) or [`permalinks`](#permalinks), or as values in the [`enabled`](#enabled-archives) array.
+
+##### Sample
+```yml
+enabled: [tags]
+layouts:
+ tag-toc: "table-of-content"
+types:
+ tag-index: "tag"
+ tag: "tag"
+permalinks:
+  tag: '/tag/:name/`
+  tag-toc: '/tag/:name/toc/`
 ```

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -1,6 +1,6 @@
 # Layouts
 
-Archives layouts are special layouts that specify how an archive page is displayed. Special attributes are available to these layouts to represent information about the specific layout being generated. These layouts are otherwise identical to regular Jekyll layouts. To handle the variety of cases presented through the attributes, we recommend that you use [type-specific layouts](./configuration.md#type-specific-layouts). 
+Archives layouts are special layouts that specify how an archive page is displayed. Special attributes are available to these layouts to represent information about the specific layout being generated. These layouts are otherwise identical to regular Jekyll layouts. To handle the variety of cases presented through the attributes, we recommend that you use [archive-specific layouts](./configuration.md#archive-specific-layouts).
 
 ### Layout attributes
 #### Title (`page.title`)

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -57,9 +57,9 @@ module Jekyll
       end
 
       def read_tags
-	@config["types"].select { |id, type|
+        @config["types"].select do |id, type|
           type == "tag" && (enabled?("tags") || enabled?(id))
-        }.keys.each do |id|
+        end.keys.each do |id|
           tags.each do |title, posts|
             @archives << Archive.new(@site, title, id, posts)
           end
@@ -67,9 +67,9 @@ module Jekyll
       end
 
       def read_categories
-	@config["types"].select { |id, type|
+        @config["types"].select do |id, type|
           type == "category" && (enabled?("categories") || enabled?(id))
-        }.keys.each do |id|
+        end.keys.each do |id|
           categories.each do |title, posts|
             @archives << Archive.new(@site, title, id, posts)
           end
@@ -77,15 +77,15 @@ module Jekyll
       end
 
       def read_dates
-        ys = @config["types"].select { |id, type|
-            type == "year" && (enabled?("years") || enabled?(id))
-          }.keys
-        ms = @config["types"].select { |id, type|
-            type == "month" && (enabled?("months") || enabled?(id))
-          }.keys
-        ds = @config["types"].select { |id, type|
-            type == "day" && (enabled?("days") || enabled?(id))
-          }.keys
+        ys = @config["types"].select do |id, type|
+          type == "year" && (enabled?("years") || enabled?(id))
+        end.keys
+        ms = @config["types"].select do |id, type|
+          type == "month" && (enabled?("months") || enabled?(id))
+        end.keys
+        ds = @config["types"].select do |id, type|
+          type == "day" && (enabled?("days") || enabled?(id))
+        end.keys
         years.each do |year, posts|
           ys.each do |id|
             @archives << Archive.new(@site, { :year => year }, id, posts)

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -18,7 +18,14 @@ module Jekyll
           "day"      => "/:year/:month/:day/",
           "tag"      => "/tag/:name/",
           "category" => "/category/:name/"
-        }
+        },
+	"types"      => {
+          "year"     => "year",
+          "month"    => "month",
+          "day"      => "day",
+          "tag"      => "tag",
+          "category" => "category"
+	}
       }.freeze
 
       def initialize(config = nil)
@@ -50,28 +57,47 @@ module Jekyll
       end
 
       def read_tags
-        if enabled? "tags"
+	@config["types"].select { |id, type|
+          type == "tag" && (enabled?("tags") || enabled?(id))
+        }.keys.each do |id|
           tags.each do |title, posts|
-            @archives << Archive.new(@site, title, "tag", posts)
+            @archives << Archive.new(@site, title, id, posts)
           end
         end
       end
 
       def read_categories
-        if enabled? "categories"
+	@config["types"].select { |id, type|
+          type == "category" && (enabled?("categories") || enabled?(id))
+        }.keys.each do |id|
           categories.each do |title, posts|
-            @archives << Archive.new(@site, title, "category", posts)
+            @archives << Archive.new(@site, title, id, posts)
           end
         end
       end
 
       def read_dates
+        ys = @config["types"].select { |id, type|
+            type == "year" && (enabled?("years") || enabled?(id))
+          }.keys
+        ms = @config["types"].select { |id, type|
+            type == "month" && (enabled?("months") || enabled?(id))
+          }.keys
+        ds = @config["types"].select { |id, type|
+            type == "day" && (enabled?("days") || enabled?(id))
+          }.keys
         years.each do |year, posts|
-          @archives << Archive.new(@site, { :year => year }, "year", posts) if enabled? "year"
+          ys.each do |id|
+            @archives << Archive.new(@site, { :year => year }, id, posts)
+          end
           months(posts).each do |month, posts|
-            @archives << Archive.new(@site, { :year => year, :month => month }, "month", posts) if enabled? "month"
+            ms.each do |id|
+              @archives << Archive.new(@site, { :year => year, :month => month }, id, posts)
+            end
             days(posts).each do |day, posts|
-              @archives << Archive.new(@site, { :year => year, :month => month, :day => day }, "day", posts) if enabled? "day"
+              ds.each do |id|
+                @archives << Archive.new(@site, { :year => year, :month => month, :day => day }, id, posts)
+              end
             end
           end
         end

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -55,23 +55,23 @@ module Jekyll
       end
 
       def read_tags
-        @config["types"].select { |id, type| type == "tag" && (enabled?("tags") || enabled?(id)) }.each_key { |id| tags.each { |title, posts| @archives << Archive.new(@site, title, id, posts) } }
+        advanced_helper_method("tag", "tags", tags)
       end
 
       def read_categories
-        @config["types"].select { |id, type| type == "category" && (enabled?("categories") || enabled?(id)) }.each_key { |id| categories.each { |title, posts| @archives << Archive.new(@site, title, id, posts) } }
+        advanced_helper_method("category", "categories", categories)
       end
 
       def enabled_years
-        @config["types"].select { |id, type| type == "year" && (enabled?("years") || enabled?(id)) }.keys
+        basic_helper_method("year", "years").keys
       end
 
       def enabled_months
-        @config["types"].select { |id, type| type == "month" && (enabled?("months") || enabled?(id)) }.keys
+        basic_helper_method("month", "months").keys
       end
 
       def enabled_days
-        @config["types"].select { |id, type| type == "day" && (enabled?("days") || enabled?(id)) }.keys
+        basic_helper_method("day", "days").keys
       end
 
       def read_dates
@@ -131,6 +131,23 @@ module Jekyll
         hash.each_value { |posts| posts.sort!.reverse! }
         hash
       end
+
+      private
+
+      def basic_helper_method(singular, plural)
+        @config["types"].select do |id, type|
+          type == singular && (enabled?(plural) || enabled?(id))
+        end
+      end
+
+      def advanced_helper_method(singular, plural, bucket)
+        basic_helper_method(singular, plural).each_key do |id|
+          bucket.each do |title, posts|
+            @archives << Archive.new(@site, title, id, posts)
+          end
+        end
+      end
+
     end
   end
 end

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -147,7 +147,6 @@ module Jekyll
           end
         end
       end
-
     end
   end
 end

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -21,13 +21,13 @@ module Jekyll
           "tag"      => "/tag/:name/",
           "category" => "/category/:name/",
         },
-	"types"      => {
+        "types"      => {
           "year"     => "year",
           "month"    => "month",
           "day"      => "day",
           "tag"      => "tag",
-          "category" => "category"
-	}
+          "category" => "category",
+        },
       }.freeze
 
       def initialize(config = nil)
@@ -55,47 +55,35 @@ module Jekyll
       end
 
       def read_tags
-        @config["types"].select do |id, type|
-          type == "tag" && (enabled?("tags") || enabled?(id))
-        end.keys.each do |id|
-          tags.each do |title, posts|
-            @archives << Archive.new(@site, title, id, posts)
-          end
-        end
+        @config["types"].select { |id, type| type == "tag" && (enabled?("tags") || enabled?(id)) }.each_key { |id| tags.each { |title, posts| @archives << Archive.new(@site, title, id, posts) } }
       end
 
       def read_categories
-        @config["types"].select do |id, type|
-          type == "category" && (enabled?("categories") || enabled?(id))
-        end.keys.each do |id|
-          categories.each do |title, posts|
-            @archives << Archive.new(@site, title, id, posts)
-          end
-        end
+        @config["types"].select { |id, type| type == "category" && (enabled?("categories") || enabled?(id)) }.each_key { |id| categories.each { |title, posts| @archives << Archive.new(@site, title, id, posts) } }
+      end
+
+      def enabled_years
+        @config["types"].select { |id, type| type == "year" && (enabled?("years") || enabled?(id)) }.keys
+      end
+
+      def enabled_months
+        @config["types"].select { |id, type| type == "month" && (enabled?("months") || enabled?(id)) }.keys
+      end
+
+      def enabled_days
+        @config["types"].select { |id, type| type == "day" && (enabled?("days") || enabled?(id)) }.keys
       end
 
       def read_dates
-        ys = @config["types"].select do |id, type|
-          type == "year" && (enabled?("years") || enabled?(id))
-        end.keys
-        ms = @config["types"].select do |id, type|
-          type == "month" && (enabled?("months") || enabled?(id))
-        end.keys
-        ds = @config["types"].select do |id, type|
-          type == "day" && (enabled?("days") || enabled?(id))
-        end.keys
+        ys = enabled_years
+        ms = enabled_months
+        ds = enabled_days
         years.each do |year, posts|
-          ys.each do |id|
-            @archives << Archive.new(@site, { :year => year }, id, posts)
-          end
+          ys.each { |id| @archives << Archive.new(@site, { :year => year }, id, posts) }
           months(posts).each do |month, posts|
-            ms.each do |id|
-              @archives << Archive.new(@site, { :year => year, :month => month }, id, posts)
-            end
+            ms.each { |id| @archives << Archive.new(@site, { :year => year, :month => month }, id, posts) }
             days(posts).each do |day, posts|
-              ds.each do |id|
-                @archives << Archive.new(@site, { :year => year, :month => month, :day => day }, id, posts)
-              end
+              ds.each { |id| @archives << Archive.new(@site, { :year => year, :month => month, :day => day }, id, posts) }
             end
           end
         end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -26,7 +26,7 @@ module Jekyll
       def initialize(site, title, id, posts)
         @site   = site
         @posts  = posts
-	@id = id
+        @id = id
         @title  = title
         @config = site.config["jekyll-archives"]
         @type = @config["types"][id]

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -22,13 +22,13 @@ module Jekyll
       # site  - The Site object.
       # title - The name of the tag/category or a Hash of the year/month/day in case of date.
       #           e.g. { :year => 2014, :month => 08 } or "my-category" or "my-tag".
-      # id  - The id of archive. Must be a key of @config["types"],
+      # id  - The id of archive. `site.config["jekyll-archives"]["types"]`,
       #           with the corresponding value being one of "year", "month", "day", "category", or "tag".
       # posts - The array of posts that belong in this archive.
       def initialize(site, title, id, posts)
         @site   = site
         @posts  = posts
-        @id = id
+        @id     = id
         @title  = title
         @config = site.config["jekyll-archives"]
         @type = @config["types"][id]
@@ -53,15 +53,15 @@ module Jekyll
       # Returns the template String.
       def template
         @config["permalinks"][@id] || (
-          case @type
+          case type
           when "tag", "category"
-            then "#{@id}/:name/"
+            "#{@id}/:name/"
           when "year"
-            then "#{@id}/:year/"
+            "#{@id}/:year/"
           when "month"
-            then "#{@id}/:year/:month/"
+            "#{@id}/:year/:month/"
           when "day"
-            then "#{@id}/:year/:month/:day/"
+            "#{@id}/:year/:month/:day/"
           end
         )
       end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -20,14 +20,16 @@ module Jekyll
       # site  - The Site object.
       # title - The name of the tag/category or a Hash of the year/month/day in case of date.
       #           e.g. { :year => 2014, :month => 08 } or "my-category" or "my-tag".
-      # type  - The type of archive. Can be one of "year", "month", "day", "category", or "tag"
+      # id  - The id of archive. Must be a key of @config["types"],
+      #           with the corresponding value being one of "year", "month", "day", "category", or "tag".
       # posts - The array of posts that belong in this archive.
-      def initialize(site, title, type, posts)
+      def initialize(site, title, id, posts)
         @site   = site
         @posts  = posts
-        @type   = type
+	@id = id
         @title  = title
         @config = site.config["jekyll-archives"]
+        @type = @config["types"][id]
 
         # Generate slug if tag or category
         # (taken from jekyll/jekyll/features/support/env.rb)
@@ -48,15 +50,26 @@ module Jekyll
       #
       # Returns the template String.
       def template
-        @config["permalinks"][type]
+        @config["permalinks"][@id] || (
+          case @type
+          when "tag", "category"
+            then "#{@id}/:name/"
+          when "year"
+            then "#{@id}/:year/"
+          when "month"
+            then "#{@id}/:year/:month/"
+          when "day"
+            then "#{@id}/:year/:month/:day/"
+          end
+        )
       end
 
       # The layout to use for rendering
       #
       # Returns the layout as a String
       def layout
-        if @config["layouts"] && @config["layouts"][type]
-          @config["layouts"][type]
+        if @config["layouts"] && @config["layouts"][@id]
+          @config["layouts"][@id]
         else
           @config["layout"]
         end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -22,16 +22,16 @@ module Jekyll
       # site  - The Site object.
       # title - The name of the tag/category or a Hash of the year/month/day in case of date.
       #           e.g. { :year => 2014, :month => 08 } or "my-category" or "my-tag".
-      # id  - The id of archive. `site.config["jekyll-archives"]["types"]`,
+      # key   - The id of archive. `site.config["jekyll-archives"]["types"]`,
       #           with the corresponding value being one of "year", "month", "day", "category", or "tag".
       # posts - The array of posts that belong in this archive.
-      def initialize(site, title, id, posts)
+      def initialize(site, title, key, posts)
         @site   = site
         @posts  = posts
-        @id     = id
+        @key    = key
         @title  = title
         @config = site.config["jekyll-archives"]
-        @type = @config["types"][id]
+        @type   = @config["types"][key]
 
         # Generate slug if tag or category
         # (taken from jekyll/jekyll/features/support/env.rb)
@@ -52,16 +52,16 @@ module Jekyll
       #
       # Returns the template String.
       def template
-        @config["permalinks"][@id] || (
+        @config["permalinks"][@key] || (
           case type
           when "tag", "category"
-            "#{@id}/:name/"
+            "#{@key}/:name/"
           when "year"
-            "#{@id}/:year/"
+            "#{@key}/:year/"
           when "month"
-            "#{@id}/:year/:month/"
+            "#{@key}/:year/:month/"
           when "day"
-            "#{@id}/:year/:month/:day/"
+            "#{@key}/:year/:month/:day/"
           end
         )
       end
@@ -70,8 +70,8 @@ module Jekyll
       #
       # Returns the layout as a String
       def layout
-        if @config["layouts"] && @config["layouts"][@id]
-          @config["layouts"][@id]
+        if @config["layouts"] && @config["layouts"][@key]
+          @config["layouts"][@key]
         else
           @config["layout"]
         end

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -2,7 +2,7 @@
 
 require "helper"
 
-class TestJekyllArchives < Minitest::Test
+class TestJekyllArchivesBasics < Minitest::Test
   context "the jekyll-archives plugin" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -47,7 +47,9 @@ class TestJekyllArchives < Minitest::Test
       assert_equal "Test", read_file("tag/test-tag/index.html")
     end
   end
+end
 
+class TestJekyllArchivesCustomLayout < Minitest::Test
   context "the jekyll-archives plugin with custom layout path" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -82,7 +84,9 @@ class TestJekyllArchives < Minitest::Test
       assert_equal "Test", read_file("/tag/test-tag/index.html")
     end
   end
+end
 
+class TestJekyllArchivesPermalink < Minitest::Test
   context "the jekyll-archives plugin with custom permalinks" do
     setup do
       @site = fixture_site(
@@ -106,7 +110,9 @@ class TestJekyllArchives < Minitest::Test
       assert archive_exists? @site, "category-plugins.html"
     end
   end
+end
 
+class TestJekyllArchivesLiquid < Minitest::Test
   context "the archives" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -119,7 +125,9 @@ class TestJekyllArchives < Minitest::Test
       assert_equal 12, read_file("length.html").to_i
     end
   end
+end
 
+class TestJekyllArchivesDefault < Minitest::Test
   context "the jekyll-archives plugin with default config" do
     setup do
       @site = fixture_site
@@ -130,29 +138,9 @@ class TestJekyllArchives < Minitest::Test
       assert_equal 0, read_file("length.html").to_i
     end
   end
+end
 
-  context "the jekyll-archives plugin with enabled array" do
-    setup do
-      @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["tags"],
-      })
-      @site.process
-    end
-
-    should "generate the enabled archives" do
-      assert archive_exists? @site, "tag/test-tag/index.html"
-      assert archive_exists? @site, "tag/tagged/index.html"
-      assert archive_exists? @site, "tag/new/index.html"
-    end
-
-    should "not generate the disabled archives" do
-      assert !archive_exists?(@site, "2014/index.html")
-      assert !archive_exists?(@site, "2014/08/index.html")
-      assert !archive_exists?(@site, "2013/08/16/index.html")
-      assert !archive_exists?(@site, "category/plugins/index.html")
-    end
-  end
-
+class TestJekyllArchivesFileds < Minitest::Test
   context "the jekyll-archives plugin" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -189,7 +177,33 @@ class TestJekyllArchives < Minitest::Test
       assert @day_archive.date.is_a? Date
     end
   end
+end
 
+class TestJekyllArchivesEnabling < Minitest::Test
+  context "the jekyll-archives plugin with enabled array" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["tags"],
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists? @site, "tag/test-tag/index.html"
+      assert archive_exists? @site, "tag/tagged/index.html"
+      assert archive_exists? @site, "tag/new/index.html"
+    end
+
+    should "not generate the disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+    end
+  end
+end
+
+class TestJekyllArchivesTags < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default tag archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -243,7 +257,9 @@ class TestJekyllArchives < Minitest::Test
       assert !archive_exists?(@site, "category/plugins/index.html")
     end
   end
+end
 
+class TestJekyllArchivesCategories < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default category archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -293,7 +309,9 @@ class TestJekyllArchives < Minitest::Test
       assert !archive_exists?(@site, "tag/new/index.html")
     end
   end
+end
 
+class TestJekyllArchivesYears < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default year archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -343,7 +361,9 @@ class TestJekyllArchives < Minitest::Test
       assert !archive_exists?(@site, "tag/new/index.html")
     end
   end
+end
 
+class TestJekyllArchivesMonths < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default month archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -393,7 +413,9 @@ class TestJekyllArchives < Minitest::Test
       assert !archive_exists?(@site, "tag/new/index.html")
     end
   end
+end
 
+class TestJekyllArchivesDays < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default day archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
@@ -443,7 +465,9 @@ class TestJekyllArchives < Minitest::Test
       assert !archive_exists?(@site, "tag/new/index.html")
     end
   end
+end
 
+class TestJekyllArchivesNonDefault < Minitest::Test
   context "the jekyll-archives plugin with non-default archives defined and only default archives enabled" do
     setup do
       @site = fixture_site("jekyll-archives" => {

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -191,9 +191,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default tag archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["foo"],
-	"types" => { "foo" => "tag"},
-	"permalinks" => { "foo" => "/t/:name/"}
+        "enabled"    => ["foo"],
+        "types"      => { "foo" => "tag" },
+        "permalinks" => { "foo" => "/t/:name/" },
       })
       @site.process
     end
@@ -218,9 +218,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with all tags enabled and non-default tag archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["tags"],
-	"types" => { "foo" => "tag"},
-	"permalinks" => { "foo" => "/t/:name/"}
+        "enabled"    => ["tags"],
+        "types"      => { "foo" => "tag" },
+        "permalinks" => { "foo" => "/t/:name/" },
       })
       @site.process
     end
@@ -245,9 +245,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default category archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["foo"],
-	"types" => { "foo" => "category"},
-	"permalinks" => { "foo" => "/c/:name/"}
+        "enabled"    => ["foo"],
+        "types"      => { "foo" => "category" },
+        "permalinks" => { "foo" => "/c/:name/" },
       })
       @site.process
     end
@@ -270,9 +270,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with all categories enabled and non-default category archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["categories"],
-	"types" => { "foo" => "category"},
-	"permalinks" => { "foo" => "/c/:name/"}
+        "enabled"    => ["categories"],
+        "types"      => { "foo" => "category" },
+        "permalinks" => { "foo" => "/c/:name/" },
       })
       @site.process
     end
@@ -295,9 +295,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default year archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["foo"],
-	"types" => { "foo" => "year"},
-	"permalinks" => { "foo" => "/y/:year/"}
+        "enabled"    => ["foo"],
+        "types"      => { "foo" => "year" },
+        "permalinks" => { "foo" => "/y/:year/" },
       })
       @site.process
     end
@@ -320,9 +320,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with all years enabled and non-default year archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["years"],
-	"types" => { "foo" => "year"},
-	"permalinks" => { "foo" => "/y/:year/"}
+        "enabled"    => ["years"],
+        "types"      => { "foo" => "year" },
+        "permalinks" => { "foo" => "/y/:year/" },
       })
       @site.process
     end
@@ -345,9 +345,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default month archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["foo"],
-	"types" => { "foo" => "month"},
-	"permalinks" => { "foo" => "/m/:year/:month/"}
+        "enabled"    => ["foo"],
+        "types"      => { "foo" => "month" },
+        "permalinks" => { "foo" => "/m/:year/:month/" },
       })
       @site.process
     end
@@ -370,9 +370,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with all months enabled and non-default month archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["months"],
-	"types" => { "foo" => "month"},
-	"permalinks" => { "foo" => "/m/:year/:month/"}
+        "enabled"    => ["months"],
+        "types"      => { "foo" => "month" },
+        "permalinks" => { "foo" => "/m/:year/:month/" },
       })
       @site.process
     end
@@ -395,9 +395,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with an enabled non-default day archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["foo"],
-	"types" => { "foo" => "day"},
-	"permalinks" => { "foo" => "/d/:year/:month/:day/"}
+        "enabled"    => ["foo"],
+        "types"      => { "foo" => "day" },
+        "permalinks" => { "foo" => "/d/:year/:month/:day/" },
       })
       @site.process
     end
@@ -420,9 +420,9 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with all days enabled and non-default day archive" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["days"],
-	"types" => { "foo" => "day"},
-	"permalinks" => { "foo" => "/d/:year/:month/:day/"}
+        "enabled"    => ["days"],
+        "types"      => { "foo" => "day" },
+        "permalinks" => { "foo" => "/d/:year/:month/:day/" },
       })
       @site.process
     end
@@ -445,21 +445,21 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with non-default archives defined and only default archives enabled" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => ["tag", "category", "year", "month", "day"],
-	"types" => {
-		"t" => "tag",
-		"c" => "category",
-		"y" => "year",
-		"m" => "month",
-		"d" => "day"
-	},
-	"permalinks" => {
-		"t" => "/t/:name/",
-		"c" => "/c/:name/",
-		"y" => "/y/:year/",
-		"m" => "/m/:year/:month/",
-		"d" => "/d/:year/:month/:day/"
-	}
+        "enabled"    => %w(tag category year month day),
+        "types"      => {
+          "t" => "tag",
+          "c" => "category",
+          "y" => "year",
+          "m" => "month",
+          "d" => "day",
+        },
+        "permalinks" => {
+          "t" => "/t/:name/",
+          "c" => "/c/:name/",
+          "y" => "/y/:year/",
+          "m" => "/m/:year/:month/",
+          "d" => "/d/:year/:month/:day/",
+        },
       })
       @site.process
     end
@@ -488,21 +488,21 @@ class TestJekyllArchives < Minitest::Test
   context "the jekyll-archives plugin with non-default archives defined and all enabled" do
     setup do
       @site = fixture_site("jekyll-archives" => {
-        "enabled" => "all",
-	"types" => {
-		"t" => "tag",
-		"c" => "category",
-		"y" => "year",
-		"m" => "month",
-		"d" => "day"
-	},
-	"permalinks" => {
-		"t" => "/t/:name/",
-		"c" => "/c/:name/",
-		"y" => "/y/:year/",
-		"m" => "/m/:year/:month/",
-		"d" => "/d/:year/:month/:day/"
-	}
+        "enabled"    => "all",
+        "types"      => {
+          "t" => "tag",
+          "c" => "category",
+          "y" => "year",
+          "m" => "month",
+          "d" => "day",
+        },
+        "permalinks" => {
+          "t" => "/t/:name/",
+          "c" => "/c/:name/",
+          "y" => "/y/:year/",
+          "m" => "/m/:year/:month/",
+          "d" => "/d/:year/:month/:day/",
+        },
       })
       @site.process
     end
@@ -532,13 +532,13 @@ class TestJekyllArchives < Minitest::Test
     setup do
       @site = fixture_site("jekyll-archives" => {
         "enabled" => "all",
-	"types" => {
-		"foo-t" => "tag",
-		"foo-c" => "category",
-		"foo-y" => "year",
-		"foo-m" => "month",
-		"foo-d" => "day"
-	},
+        "types"   => {
+          "foo-t" => "tag",
+          "foo-c" => "category",
+          "foo-y" => "year",
+          "foo-m" => "month",
+          "foo-d" => "day",
+        },
       })
       @site.process
     end

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -187,4 +187,370 @@ class TestJekyllArchives < Minitest::Test
       assert @day_archive.date.is_a? Date
     end
   end
+
+  context "the jekyll-archives plugin with an enabled non-default tag archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["foo"],
+	"types" => { "foo" => "tag"},
+	"permalinks" => { "foo" => "/t/:name/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists? @site, "t/test-tag/index.html"
+      assert archive_exists? @site, "t/tagged/index.html"
+      assert archive_exists? @site, "t/new/index.html"
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with all tags enabled and non-default tag archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["tags"],
+	"types" => { "foo" => "tag"},
+	"permalinks" => { "foo" => "/t/:name/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists? @site, "tag/test-tag/index.html"
+      assert archive_exists? @site, "tag/tagged/index.html"
+      assert archive_exists? @site, "tag/new/index.html"
+      assert archive_exists? @site, "t/test-tag/index.html"
+      assert archive_exists? @site, "t/tagged/index.html"
+      assert archive_exists? @site, "t/new/index.html"
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with an enabled non-default category archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["foo"],
+	"types" => { "foo" => "category"},
+	"permalinks" => { "foo" => "/c/:name/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "c/plugins/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with all categories enabled and non-default category archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["categories"],
+	"types" => { "foo" => "category"},
+	"permalinks" => { "foo" => "/c/:name/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "category/plugins/index.html")
+      assert archive_exists?(@site, "c/plugins/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with an enabled non-default year archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["foo"],
+	"types" => { "foo" => "year"},
+	"permalinks" => { "foo" => "/y/:year/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "y/2014/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with all years enabled and non-default year archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["years"],
+	"types" => { "foo" => "year"},
+	"permalinks" => { "foo" => "/y/:year/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "2014/index.html")
+      assert archive_exists?(@site, "y/2014/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with an enabled non-default month archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["foo"],
+	"types" => { "foo" => "month"},
+	"permalinks" => { "foo" => "/m/:year/:month/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "m/2014/08/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with all months enabled and non-default month archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["months"],
+	"types" => { "foo" => "month"},
+	"permalinks" => { "foo" => "/m/:year/:month/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "2014/08/index.html")
+      assert archive_exists?(@site, "m/2014/08/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with an enabled non-default day archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["foo"],
+	"types" => { "foo" => "day"},
+	"permalinks" => { "foo" => "/d/:year/:month/:day/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "d/2013/08/16/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "2013/08/16/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with all days enabled and non-default day archive" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["days"],
+	"types" => { "foo" => "day"},
+	"permalinks" => { "foo" => "/d/:year/:month/:day/"}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "2013/08/16/index.html")
+      assert archive_exists?(@site, "d/2013/08/16/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "2014/index.html")
+      assert !archive_exists?(@site, "2014/08/index.html")
+      assert !archive_exists?(@site, "category/plugins/index.html")
+      assert !archive_exists?(@site, "tag/test-tag/index.html")
+      assert !archive_exists?(@site, "tag/tagged/index.html")
+      assert !archive_exists?(@site, "tag/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with non-default archives defined and only default archives enabled" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => ["tag", "category", "year", "month", "day"],
+	"types" => {
+		"t" => "tag",
+		"c" => "category",
+		"y" => "year",
+		"m" => "month",
+		"d" => "day"
+	},
+	"permalinks" => {
+		"t" => "/t/:name/",
+		"c" => "/c/:name/",
+		"y" => "/y/:year/",
+		"m" => "/m/:year/:month/",
+		"d" => "/d/:year/:month/:day/"
+	}
+      })
+      @site.process
+    end
+
+    should "generate the enabled archives" do
+      assert archive_exists?(@site, "2014/index.html")
+      assert archive_exists?(@site, "2014/08/index.html")
+      assert archive_exists?(@site, "2013/08/16/index.html")
+      assert archive_exists?(@site, "category/plugins/index.html")
+      assert archive_exists?(@site, "tag/test-tag/index.html")
+      assert archive_exists?(@site, "tag/tagged/index.html")
+      assert archive_exists?(@site, "tag/new/index.html")
+    end
+
+    should "not generate disabled archives" do
+      assert !archive_exists?(@site, "y/2014/index.html")
+      assert !archive_exists?(@site, "m/2014/08/index.html")
+      assert !archive_exists?(@site, "d/2013/08/16/index.html")
+      assert !archive_exists?(@site, "c/plugins/index.html")
+      assert !archive_exists?(@site, "t/test-tag/index.html")
+      assert !archive_exists?(@site, "t/tagged/index.html")
+      assert !archive_exists?(@site, "t/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with non-default archives defined and all enabled" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => "all",
+	"types" => {
+		"t" => "tag",
+		"c" => "category",
+		"y" => "year",
+		"m" => "month",
+		"d" => "day"
+	},
+	"permalinks" => {
+		"t" => "/t/:name/",
+		"c" => "/c/:name/",
+		"y" => "/y/:year/",
+		"m" => "/m/:year/:month/",
+		"d" => "/d/:year/:month/:day/"
+	}
+      })
+      @site.process
+    end
+
+    should "generate the default archives" do
+      assert archive_exists?(@site, "2014/index.html")
+      assert archive_exists?(@site, "2014/08/index.html")
+      assert archive_exists?(@site, "2013/08/16/index.html")
+      assert archive_exists?(@site, "category/plugins/index.html")
+      assert archive_exists?(@site, "tag/test-tag/index.html")
+      assert archive_exists?(@site, "tag/tagged/index.html")
+      assert archive_exists?(@site, "tag/new/index.html")
+    end
+
+    should "generate the custom archives" do
+      assert archive_exists?(@site, "y/2014/index.html")
+      assert archive_exists?(@site, "m/2014/08/index.html")
+      assert archive_exists?(@site, "d/2013/08/16/index.html")
+      assert archive_exists?(@site, "c/plugins/index.html")
+      assert archive_exists?(@site, "t/test-tag/index.html")
+      assert archive_exists?(@site, "t/tagged/index.html")
+      assert archive_exists?(@site, "t/new/index.html")
+    end
+  end
+
+  context "the jekyll-archives plugin with enabled non-default archives width missing permalinks" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "enabled" => "all",
+	"types" => {
+		"foo-t" => "tag",
+		"foo-c" => "category",
+		"foo-y" => "year",
+		"foo-m" => "month",
+		"foo-d" => "day"
+	},
+      })
+      @site.process
+    end
+
+    should "generate the custom archives with the fallback path" do
+      assert archive_exists?(@site, "foo-y/2014/index.html")
+      assert archive_exists?(@site, "foo-m/2014/08/index.html")
+      assert archive_exists?(@site, "foo-d/2013/08/16/index.html")
+      assert archive_exists?(@site, "foo-c/plugins/index.html")
+      assert archive_exists?(@site, "foo-t/test-tag/index.html")
+      assert archive_exists?(@site, "foo-t/tagged/index.html")
+      assert archive_exists?(@site, "foo-t/new/index.html")
+    end
+  end
 end


### PR DESCRIPTION
This change adds the ability to declare multiple archives of the same type (tag, category, year, month, or day) each using a specific permalink and layout, while maintaining compatibility with existing syntax.

The design of the feature is such that people who do not need this functionality can ignore its existence, and those who do can easily opt into it.

My personal use for this is that I want to generate two different view of the tags archive: one that is just an index of posts for each tag, with title and links, and one that inlines all the posts for that tag in a single page.

This pull request includes updates to the documentation and relevant additions to the test suite.