### PR TITLE
configuration.md - Fixed table layout 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,9 +28,10 @@ jekyll-archives:
 ---
 
 #### Enabled archives
-| Key | Value type | Values |
-|---|---|---|---|
-| `enabled` | String or Array | `'all'` or an array of any combination of `year`, `month`, `day`, `categories`, `tags` |
+Key | Value type | Values 
+-|-|-
+`enabled` | String or Array | `'all'` or an array of any combination of `year`, `month`, `day`, `categories`, `tags`
+
 ##### Description
 This option sets which types of archives will be created. Must be set to an array of enabled archive types, or the string 'all' (to enable all archives).
 ##### Sample values

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,9 +48,10 @@ enabled:
 ---
 
 #### Default layout
-| Key | Value type | Values |
-|---|---|---|---|
-| `layout` | String  | The layout name of the default archive layout |
+ Key | Value type | Values 
+-|-|-
+ `layout` | String  | The layout name of the default archive layout 
+
 ##### Description
 Sets the default layout to use if no type-specific layout (see [Type-specific layouts](#type-specific-layouts) below) for an archive is specified.
 ##### Sample values
@@ -62,9 +63,10 @@ layout: custom-archive-layout    # _layouts/custom-archive-layout.html
 ---
 
 #### Type-specific layouts
-| Key | Value type | Values |
-|---|---|---|---|
-| `layouts` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its archive name. |
+Key | Value type | Values
+-|-|-
+`layouts` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its archive name. 
+ 
 ##### Description
 Maps archive types to the layout they will be rendered in. Not all types need to be specified; those without a specific layout will fall back to the default layout.
 ##### Sample values
@@ -79,9 +81,10 @@ layouts:
 ---
 
 #### Permalinks
-| Key | Value type | Values |
-|---|---|---|---|
-| `permalinks` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its permalink format. |
+Key | Value type | Values 
+-|-|-
+`permalinks` | Map, String &rarr; String | A map of layout type (`year`, `month`, `day`, `category`, `tag`) to its permalink format.
+
 ##### Description
 Maps archive types to the permalink format used for archive pages. The permalink style is the same as regular Jekyll posts and pages, but with different variables.
 


### PR DESCRIPTION
The table layout in configuration.md under `Enabled archives` section was not properly formatted.

#### Before Change
| Key | Value type | Values |
|---|---|---|---|
| `enabled` | String or Array | `'all'` or an array of any combination of `year`, `month`, `day`, `categories`, `tags` |

#### After Change
Key | Value type | Values 
-|-|-
`enabled` | String or Array | `'all'` or an array of any combination of `year`, `month`, `day`, `categories`, `tags`