### PR TITLE
🤖 Bump rubocop to 0.56.0 / Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ Lint/ShadowingOuterLocalVariable:
   Exclude:
     - lib/jekyll-archives.rb
 
+Lint/SafeNavigationConsistency:
+  Exclude:
+    - lib/jekyll-archives/archive.rb
+
 Metrics/BlockLength:
   Exclude:
     - test/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,3 @@ if ENV["GH_PAGES"]
 elsif ENV["JEKYLL_VERSION"]
   gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
 end
-
-# Support for Ruby < 2.2.2 & activesupport
-gem "activesupport", "~> 4.2" if RUBY_VERSION < "2.2.2"

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/jekyll/jekyll-archives"
   s.licenses    = ["MIT"]
 
-  all_files       = `git ls-files -z`.split("\x0")
-  s.files         = all_files.grep(%r!^(lib)/!)
+  all_files     = `git ls-files -z`.split("\x0")
+  s.files       = all_files.grep(%r!^(lib)/!)
 
-  s.add_dependency "jekyll", ">= 3.1"
+  s.add_dependency "jekyll", "~> 3.6"
 
   s.add_development_dependency  "minitest"
   s.add_development_dependency  "rake"
   s.add_development_dependency  "rdoc"
-  s.add_development_dependency  "rubocop", "0.51"
+  s.add_development_dependency  "rubocop", "0.54.0"
   s.add_development_dependency  "shoulda"
 end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency  "minitest"
   s.add_development_dependency  "rake"
   s.add_development_dependency  "rdoc"
-  s.add_development_dependency  "rubocop", "0.54.0"
+  s.add_development_dependency  "rubocop", "0.55.0"
   s.add_development_dependency  "shoulda"
 end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency  "minitest"
   s.add_development_dependency  "rake"
   s.add_development_dependency  "rdoc"
-  s.add_development_dependency  "rubocop", "0.55.0"
+  s.add_development_dependency  "rubocop", "~> 0.56.0"
   s.add_development_dependency  "shoulda"
 end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -78,11 +78,11 @@ module Jekyll
       #
       # Returns the String url.
       def url
-        @url ||= URL.new({
+        @url ||= URL.new(
           :template     => template,
           :placeholders => url_placeholders,
-          :permalink    => nil,
-        }).to_s
+          :permalink    => nil
+        ).to_s
       rescue ArgumentError
         raise ArgumentError, "Template \"#{template}\" provided is invalid."
       end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -88,7 +88,7 @@ module Jekyll
       end
 
       def permalink
-        data && data.is_a?(Hash) && data["permalink"]
+        data&.is_a?(Hash) && data["permalink"]
       end
 
       # Produce a title object suitable for Liquid based on type of archive.

--- a/lib/jekyll-archives/version.rb
+++ b/lib/jekyll-archives/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Archives
-    VERSION = "2.1.0".freeze
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
- [x] Tested locally with Jekyll `master` rules.
- [x] Fix offenses with `script/fmt -a`
- [x] Target Ruby > 2.3 as Ruby 2.2 is EOL

### Output

```
➜ script/cibuild
Rubocop 0.55.0
Inspecting 8 files
........

8 files inspected, no offenses detected
Run options: --seed 9999

# Running:

.................

Finished in 0.501054s, 33.9285 runs/s, 77.8359 assertions/s.

17 runs, 39 assertions, 0 failures, 0 errors, 0 skips
```
