### PR TITLE
Allow testing and using with Jekyll 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 language: ruby
 cache: bundler
 rvm:
+  - &latest_ruby 2.6
   - 2.4
-  - 2.6
+  - 2.3
+
+env:
+  - JEKYLL_VERSION="~> 3.8"
 
 matrix:
   include:
     - # GitHub Pages
       rvm: 2.5.3
       env: GH_PAGES=true
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 
 before_install:
   - gem update --system
   - bundle update
 script : script/cibuild
-
-env:
-  - JEKYLL_VERSION=3.7.4
-

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gemspec
 if ENV["GH_PAGES"]
   gem "github-pages"
 elsif ENV["JEKYLL_VERSION"]
-  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+  gem "jekyll", ENV["JEKYLL_VERSION"]
 end

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.0"
 
-  s.add_dependency "jekyll", "~> 3.6"
+  s.add_dependency "jekyll", ">= 3.6", "< 5.0"
   
   s.add_development_dependency "bundler"
   s.add_development_dependency "minitest"

--- a/jekyll-archives.gemspec
+++ b/jekyll-archives.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   all_files     = `git ls-files -z`.split("\x0")
   s.files       = all_files.grep(%r!^(lib)/!)
 
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "jekyll", ">= 3.6", "< 5.0"
   


### PR DESCRIPTION
Minimal changes to allow testing with Jekyll 4.0 pre-release.

(*Should we drop support for Ruby 2.2 here for consistency?*)