### PR TITLE
Initialize Archives generator with a hash

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -23,7 +23,7 @@ module Jekyll
         },
       }.freeze
 
-      def initialize(config = nil)
+      def initialize(config = {})
         @config = Utils.deep_merge_hashes(DEFAULTS, config.fetch("jekyll-archives", {}))
       end
 


### PR DESCRIPTION
Since we're calling `config.fetch` invariably without handling `nil`, its better that we set the optional parameter as an empty hash lest a `NoMethodError: undefined method 'fetch' for nil:NilClass` be raised.

The reason why this remained concealed all this while is because `Jekyll::Site` automatically initializes all `Jekyll::Generator` subclasses with `site.config`. Therefore, this change is not going to cause any impact whatsoever, but is correcting a wrong nevertheless.

