### PR TITLE
Remove support for legacy Jekyll versions

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -93,13 +93,7 @@ module Jekyll
       # Custom `post_attr_hash` method for years
       def years
         hash = Hash.new { |h, key| h[key] = [] }
-
-        # In Jekyll 3, Collection#each should be called on the #docs array directly.
-        if Jekyll::VERSION >= "3.0.0"
-          @posts.docs.each { |p| hash[p.date.strftime("%Y")] << p }
-        else
-          @posts.each { |p| hash[p.date.strftime("%Y")] << p }
-        end
+        @posts.docs.each { |p| hash[p.date.strftime("%Y")] << p }
         hash.each_value { |posts| posts.sort!.reverse! }
         hash
       end


### PR DESCRIPTION
The `gemspec` dropped support for versions older than `Jekyll 3.1` in https://github.com/jekyll/jekyll-archives/commit/a7a5a84cd398e9e3484a7719ce18ee9931ad8392 which is part of latest released version.

This removes the now redundant code to support legacy Jekyll versions