### PR TITLE
Read-in site's tags and categories attributes

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -83,11 +83,11 @@ module Jekyll
       end
 
       def tags
-        @site.post_attr_hash("tags")
+        @site.tags
       end
 
       def categories
-        @site.post_attr_hash("categories")
+        @site.categories
       end
 
       # Custom `post_attr_hash` method for years


### PR DESCRIPTION
`Jekyll::Site#tags` and `Jekyll::Site#categories` (introduced in Jekyll 2.0 via https://github.com/jekyll/jekyll/commit/8c0e5d8d98b2713339d4c73359017e8303c684af) already encapsulate the exact same logic:
```ruby
# As of Jekyll 3.8.5

    def post_attr_hash(post_attr)
      # Build a hash map based on the specified post attribute ( post attr =>
      # array of posts ) then sort each array in reverse order.
      hash = Hash.new { |h, key| h[key] = [] }
      posts.docs.each do |p|
        p.data[post_attr].each { |t| hash[t] << p } if p.data[post_attr]
      end
      hash.each_value { |posts| posts.sort!.reverse! }
      hash
    end

    def tags
      post_attr_hash("tags")
    end

    def categories
      post_attr_hash("categories")
    end
```
So, we might as well just delegate to the methods in `Jekyll::Site`.
However, it's not much of a concern since `Archives#tags` and `Archives#categories` are called at most just once per call to the `Archives#generate` method.

--

*Notes:
  - I refrained from using `extend Forwardable` and `def_delegators` since we're dealing with just two methods here.
  - In Jekyll 4.0, `Jekyll::Site#post_attr_hash` is a memoized method. So there wont be additional hash allocation for each call to `Archives#tags` and `Archives#categories`.