### PR TITLE
Return unless 'jekyll-archives' config is a Hash

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -24,10 +24,19 @@ module Jekyll
       }.freeze
 
       def initialize(config = {})
-        @config = Utils.deep_merge_hashes(DEFAULTS, config.fetch("jekyll-archives", {}))
+        archives_config = config.fetch("jekyll-archives", {})
+        if archives_config.is_a?(Hash)
+          @config = Utils.deep_merge_hashes(DEFAULTS, archives_config)
+        else
+          @config = nil
+          Jekyll.logger.warn "Archives:", "Expected a hash but got #{archives_config.inspect}"
+          Jekyll.logger.warn "", "Archives will not be generated for this site."
+        end
       end
 
       def generate(site)
+        return if @config.nil?
+
         @site = site
         @posts = site.posts
         @archives = []

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,5 +41,16 @@ module Minitest
 
       File.read(read_path).strip
     end
+
+    def capture_output(level = :debug)
+      buffer = StringIO.new
+      Jekyll.logger = Logger.new(buffer)
+      Jekyll.logger.log_level = level
+      yield
+      buffer.rewind
+      buffer.string.to_s
+    ensure
+      Jekyll.logger = Logger.new(StringIO.new, :error)
+    end
   end
 end

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -189,4 +189,43 @@ class TestJekyllArchives < Minitest::Test
       assert @day_archive.date.is_a? Date
     end
   end
+
+  context "the jekyll-archives plugin with a non-hash config" do
+    should "output a warning" do
+      output = capture_output do
+        site = fixture_site("jekyll-archives" => %w(apples oranges))
+        site.read
+        site.generate
+      end
+      assert_includes output, "Archives: Expected a hash but got [\"apples\", \"oranges\"]"
+      assert_includes output, "Archives will not be generated for this site."
+
+      output = capture_output do
+        site = fixture_site("jekyll-archives" => nil)
+        site.read
+        site.generate
+      end
+      assert_includes output, "Archives: Expected a hash but got nil"
+      assert_includes output, "Archives will not be generated for this site."
+    end
+
+    should "not generate archive pages" do
+      capture_output do
+        site = fixture_site("jekyll-archives" => nil)
+        site.read
+        site.generate
+        assert_nil(site.pages.find { |p| p.is_a?(Jekyll::Archives::Archive) })
+      end
+    end
+
+    should "be fine with a basic config" do
+      output = capture_output do
+        @site = fixture_site("title" => "Hello World")
+        @site.read
+        @site.generate
+      end
+      refute_includes output, "Archives: Expected a hash but got nil"
+      assert_nil(@site.pages.find { |p| p.is_a?(Jekyll::Archives::Archive) })
+    end
+  end
 end


### PR DESCRIPTION
If the user or a third-party plugins *sets* `config["jekyll-archives"]` to `nil` or something but a Hash, output a warning and turn-off the archives generator.

Closes #138 