### PR TITLE
Memoize date attribute of date-type archive pages

### DIFF
--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -99,7 +99,9 @@ module Jekyll
       #
       # Returns a Date.
       def date
-        if @title.is_a? Hash
+        return unless @title.is_a?(Hash)
+
+        @date ||= begin
           args = @title.values.map(&:to_i)
           Date.new(*args)
         end


### PR DESCRIPTION
So that a new `Date` object is not created on every call