### PR TITLE
Implement basic support for collections

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ jekyll-archives:
 #### Optional settings
 - [Default layout (`layout`)](#default-layout)
 - [Permalinks (`permalinks`)](#permalinks)
-
+- [Collections (`collections`)](#collections)
 ---
 
 #### Enabled archives
@@ -120,4 +120,25 @@ permalinks:
   year: '/archives/year/:year/'
   month: '/archives/month/:year-:month/'
   tag: '/archives/tag/:name/'
+```
+
+---
+
+#### Collections
+
+| Key          | Value type                | Values |
+|--------------|---------------------------|--------|
+| `collections.merge_tags` | Bool | Whether to retrieve tags also from custom collections. (default: `false`) |
+
+##### Description
+The `collections` map contains settings affecting the custom collections support.
+
+##### merge_tags
+Whether to add tags from pages inside custom collections into the global tags pool.
+
+##### Sample values
+
+```yml
+collections:
+  merge_tags: true
 ```

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -1,6 +1,6 @@
 # Layouts
 
-Archives layouts are special layouts that specify how an archive page is displayed. Special attributes are available to these layouts to represent information about the specific layout being generated. These layouts are otherwise identical to regular Jekyll layouts. To handle the variety of cases presented through the attributes, we recommend that you use [type-specific layouts](./configuration.md#type-specific-layouts). 
+Archives layouts are special layouts that specify how an archive page is displayed. Special attributes are available to these layouts to represent information about the specific layout being generated. These layouts are otherwise identical to regular Jekyll layouts. To handle the variety of cases presented through the attributes, we recommend that you use [type-specific layouts](./configuration.md#type-specific-layouts).
 
 ### Layout attributes
 #### Title (`page.title`)
@@ -11,6 +11,10 @@ In the case of a date archive, this attribute contains a Date object that can be
 
 #### Posts (`page.posts`)
 The `page.posts` attribute contains an array of Post objects matching the archive criteria. You can iterate over this array just like any other Post array in Jekyll.
+
+#### Collections (`page.collections`)
+This attribute is a hash of `collection label -> []Post` pairs, splitting the posts in this archive by the collection they are in.
+See [Jekyll documentation](https://jekyllrb.com/docs/collections/) for more information about collections.
 
 #### Type (`page.type`)
 This attribute contains a simple string indicating the type of the layout being generated. Its value can be one of `tag`, `category`, `year`, `month`, or `day`.

--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -59,6 +59,16 @@ module Jekyll
 
       def read_tags
         if enabled? "tags"
+          if @config["collections"]&.fetch("merge_tags", false)
+            @site.collections.each do |_, col|
+              col.docs.each do |post|
+                post.data["tags"].each do |tag|
+                  tags[tag].nil? ? tags[tag] = [ post ] : tags[tag].push(post)
+                end
+              end
+            end
+          end
+
           tags.each do |title, posts|
             @archives << Archive.new(@site, title, "tag", posts)
           end

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -3,11 +3,12 @@
 module Jekyll
   module Archives
     class Archive < Jekyll::Page
-      attr_accessor :posts, :type, :slug
+      attr_accessor :posts, :type, :slug, :collections
 
       # Attributes for Liquid templates
       ATTRIBUTES_FOR_LIQUID = %w(
         posts
+        collections
         type
         title
         date
@@ -30,6 +31,16 @@ module Jekyll
         @type   = type
         @title  = title
         @config = site.config["jekyll-archives"]
+
+        @collections = {}
+        posts.each do |post|
+          l = post.collection.label
+          if @collections.has_key?(l)
+            @collections[l] << post
+          else
+            @collections[l] = [ post ]
+          end
+        end
 
         # Generate slug if tag or category
         # (taken from jekyll/jekyll/features/support/env.rb)

--- a/test/source/_foo/2020-03-20-tagged-collection-post.md
+++ b/test/source/_foo/2020-03-20-tagged-collection-post.md
@@ -1,0 +1,6 @@
+---
+title: Tagged post in a collection
+tags: ["Test Tag", tagged, "collection" ]
+---
+
+This is a tagged post in a collection

--- a/test/test_jekyll_archives.rb
+++ b/test/test_jekyll_archives.rb
@@ -228,4 +228,24 @@ class TestJekyllArchives < Minitest::Test
       assert_nil(@site.pages.find { |p| p.is_a?(Jekyll::Archives::Archive) })
     end
   end
+
+  context "the jekyll-archives plugin with tags from collections" do
+    setup do
+      @site = fixture_site("jekyll-archives" => {
+        "layout"  => "archive-too",
+        "enabled" => true,
+        "collections" => {
+          "merge_tags" => true,
+        }
+      }, "collections" => {
+        "foo" => { }
+      })
+      @site.process
+    end
+
+    should "generate tags for collections" do
+      @site.process
+      assert archive_exists? @site, "tag/collection/index.html"
+    end
+  end
 end


### PR DESCRIPTION
This does two things:

1. Optionally, merges tags from all collections into the global tags pool
2. Adds `post.collections` attribute to the archive layout, so you can split the page by collection.