### PR TITLE
Added the "slug_mode" option to URL generation.

### DIFF
--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -33,7 +33,7 @@ module Jekyll
 
         # Generate slug if tag or category
         # (taken from jekyll/jekyll/features/support/env.rb)
-        @slug = Utils.slugify(title) if title.is_a? String
+        @slug = Utils.slugify(title, mode: @config["slug_mode"]) if title.is_a? String
 
         # Use ".html" for file extension and url for path
         @ext  = File.extname(relative_path)


### PR DESCRIPTION
This commit helps with localization of URLs for sites that use category and tag names that have accented characters. By using the "slug_mode" option in the site's configuration file, the user can apply the correspondent mode of the "Utils.slugify" method to the generated directory name and URL. Issue #121 should be resolved by this.