### PR TITLE
Use Liquid drop to expose attributes to templates

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -5,8 +5,9 @@ require "jekyll"
 module Jekyll
   module Archives
     # Internal requires
-    autoload :Archive, "jekyll-archives/archive"
-    autoload :VERSION, "jekyll-archives/version"
+    autoload :Archive,  "jekyll-archives/archive"
+    autoload :PageDrop, "jekyll-archives/page_drop"
+    autoload :VERSION,  "jekyll-archives/version"
 
     class Archives < Jekyll::Generator
       safe true

--- a/lib/jekyll-archives/archive.rb
+++ b/lib/jekyll-archives/archive.rb
@@ -120,6 +120,11 @@ module Jekyll
         "#<Jekyll:Archive @type=#{@type} @title=#{@title} @data=#{@data.inspect}>"
       end
 
+      # The Liquid representation of this page.
+      def to_liquid
+        @to_liquid ||= Jekyll::Archives::PageDrop.new(self)
+      end
+
       private
 
       # Generate slug if @title attribute is a string.

--- a/lib/jekyll-archives/page_drop.rb
+++ b/lib/jekyll-archives/page_drop.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Archives
+    class PageDrop < Jekyll::Drops::Drop
+      extend Forwardable
+
+      mutable false
+
+      def_delegators :@obj, :posts, :type, :title, :date, :name, :path, :url, :permalink
+      private def_delegator :@obj, :data, :fallback_data
+    end
+  end
+end


### PR DESCRIPTION
So that attributes are computed on a *need-to-render* basis.

Closes #113 